### PR TITLE
Remove IE10 from the intern test config

### DIFF
--- a/src/intern/intern-browserstack.js
+++ b/src/intern/intern-browserstack.js
@@ -6,7 +6,7 @@ define([
 	intern.maxConcurrency = 2;
 
 	intern.environments = [
-		{ browserName: 'internet explorer', version: [ '10', '11' ], platform: 'WINDOWS' },
+		{ browserName: 'internet explorer', version: [ '11' ], platform: 'WINDOWS' },
 		{ browserName: 'firefox', platform: 'WINDOWS' },
 		{ browserName: 'chrome', platform: 'WINDOWS' }
 	];

--- a/src/intern/intern-saucelabs.js
+++ b/src/intern/intern-saucelabs.js
@@ -3,7 +3,7 @@ define([
 ], function (intern) {
 
 	intern.environments = [
-		{ browserName: 'internet explorer', version: [ '10.0', '11.0' ], platform: 'Windows 7' },
+		{ browserName: 'internet explorer', version: [ '11.0' ], platform: 'Windows 7' },
 		{ browserName: 'firefox', version: '49', platform: 'Windows 10' },
 		{ browserName: 'chrome', platform: 'Windows 10' }
 	];

--- a/src/intern/intern-testingbot.js
+++ b/src/intern/intern-testingbot.js
@@ -3,7 +3,7 @@ define([
 ], function (intern) {
 
 	intern.environments = [
-		{ browserName: 'internet explorer', version: [ '10', '11' ], platform: 'WIN8' },
+		{ browserName: 'internet explorer', version: [ '11' ], platform: 'WIN8' },
 		{ browserName: 'firefox', version: '49', platform: 'WIN10' },
 		{ browserName: 'chrome', platform: 'WIN10' }
 	];


### PR DESCRIPTION
Type: **bug**

Remove IE10 from the intern test configuration as it is not a supported browser for Dojo 2.

Resolves #6 
