### PR TITLE
Returning a status code to cli so if tests are not run successfully t…

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -58,14 +58,31 @@ export default async function (testArgs: TestArgs) {
 			color: 'white',
 			text: 'Running tests'
 		}).start();
+
+		function succeed() {
+			spinner.stopAndPersist(green.bold(' completed'));
+			resolve();
+		}
+
+		function fail(err: string) {
+			spinner.stopAndPersist(red.bold(' failed'));
+			reject({
+				message: err,
+				exitCode: 1
+			});
+		}
+
 		cs.spawn(path.resolve('node_modules/.bin/intern-runner'), parseArguments(testArgs), { stdio: 'inherit' })
-			.on('close', () => {
-				spinner.stopAndPersist(green.bold(' completed'));
-				resolve();
+			.on('close', (exitCode: number) => {
+				if (exitCode) {
+					fail('Tests did not complete successfully');
+				}
+				else {
+					succeed();
+				}
 			})
 			.on('error', (err: Error) => {
-				spinner.stopAndPersist(red.bold(' failed'));
-				reject(err);
+				fail(err.message);
 			});
 	});
 }

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -72,6 +72,19 @@ describe('runTests', () => {
 				'Should persis the failed message');
 		}
 	});
+	it('Should reject with an error when spawn exits cleanly with a non-zero status code', async () => {
+		spawnOnStub.onFirstCall().callsArgWith(1, 1);
+		try {
+			await runTests.default({});
+			assert.fail(null, null, 'Should not get here');
+		}
+		catch (error) {
+			assert.isTrue(stopAndPersistStub.calledOnce, 'Should stop the spinner');
+			assert.isTrue(stopAndPersistStub.firstCall.calledWithMatch('failed'),
+				'Should persis the failed message');
+			assert.strictEqual(error.exitCode, 1);
+		}
+	});
 
 	describe('Should parse arguments', () => {
 		it('Should use config to set intern file if provided', () => {


### PR DESCRIPTION
…he task does not report a success

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Failing tests now return an exit code, which should cause the entire process to exit with that code once https://github.com/dojo/cli/pull/114 lands.

Resolves #7 
