### PR TITLE
Issue 3

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ const command: Command = {
 	register(options: OptionsHelper) {
 		options('a', {
 			alias: 'all',
-			describe: 'Indicates that all tests (both unit and functional) should be fun. By default, only unit tests are run.',
+			describe: 'Indicates that all tests (both unit and functional) should be run. By default, only unit tests are run.',
 			default: false
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { Argv } from 'yargs';
 import runTests from './runTests';
 
 export interface TestArgs extends Argv {
+	all: boolean;
+	browser: boolean;
 	config: string;
 	unit: boolean;
 	functional: boolean;
@@ -16,6 +18,12 @@ export interface TestArgs extends Argv {
 const command: Command = {
 	description: 'test your application',
 	register(options: OptionsHelper) {
+		options('b', {
+			alias: 'browser',
+			describe: 'Indicates that unit tests should be run in the browser (default node). Note that functional tests are always run in the browser.',
+			type: 'boolean'
+		});
+
 		options('c', {
 			alias: 'config',
 			describe: 'Specifies what configuration to test with: \'local\'(default), \'browserstack\', \'testingbot\', or \'saucelabs\'.',
@@ -28,14 +36,22 @@ const command: Command = {
 			type: 'string'
 		});
 
+		options('a', {
+			alias: 'all',
+			describe: 'Indivates that all tests (both unit and functional) should be fun. By default, only unit tests are run.',
+			default: false
+		});
+
 		options('u', {
 			alias: 'unit',
-			describe: 'Indicates that only unit tests should be run. By default functional tests and unit tests are run'
+			describe: 'Indicates that only unit tests should be run. This is the default.',
+			default: true
 		});
 
 		options('f', {
 			alias: 'functional',
-			describe: 'Indicates that only functional tests should be run. By default functional tests and unit tests are run'
+			describe: 'Indicates that only functional tests should be run. By default only unit tests are run',
+			default: false
 		});
 
 		options('cov', {

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,12 @@ export interface TestArgs extends Argv {
 const command: Command = {
 	description: 'test your application',
 	register(options: OptionsHelper) {
+		options('a', {
+			alias: 'all',
+			describe: 'Indicates that all tests (both unit and functional) should be fun. By default, only unit tests are run.',
+			default: false
+		});
+
 		options('b', {
 			alias: 'browser',
 			describe: 'Indicates that unit tests should be run in the browser (default node). Note that functional tests are always run in the browser.',
@@ -30,33 +36,15 @@ const command: Command = {
 			type: 'string'
 		});
 
-		options('r', {
-			alias: 'reporters',
-			describe: 'Comma separated list of reporters to use, defaults to Console',
-			type: 'string'
-		});
-
-		options('a', {
-			alias: 'all',
-			describe: 'Indivates that all tests (both unit and functional) should be fun. By default, only unit tests are run.',
-			default: false
-		});
-
-		options('u', {
-			alias: 'unit',
-			describe: 'Indicates that only unit tests should be run. This is the default.',
-			default: true
+		options('cov', {
+			alias: 'coverage',
+			describe: 'If specified coverage will be included. This is the same as adding the LcovHtml reporter'
 		});
 
 		options('f', {
 			alias: 'functional',
 			describe: 'Indicates that only functional tests should be run. By default only unit tests are run',
 			default: false
-		});
-
-		options('cov', {
-			alias: 'coverage',
-			describe: 'If specified coverage will be included. This is the same as adding the LcovHtml reporter'
 		});
 
 		options('k', {
@@ -71,10 +59,22 @@ const command: Command = {
 			type: 'string'
 		});
 
+		options('r', {
+			alias: 'reporters',
+			describe: 'Comma separated list of reporters to use, defaults to Console',
+			type: 'string'
+		});
+
 		options('s', {
 			alias: 'secret',
 			describe: 'API secret for testingbot',
 			type: 'string'
+		});
+
+		options('u', {
+			alias: 'unit',
+			describe: 'Indicates that only unit tests should be run. This is the default.',
+			default: true
 		});
 	},
 	run(helper: Helper, args: TestArgs) {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -77,33 +77,17 @@ export default async function (testArgs: TestArgs) {
 			});
 		}
 
-		if (shouldRunInBrowser(testArgs)) {
-			cs.spawn(path.resolve('node_modules/.bin/intern-runner'), parseArguments(testArgs), { stdio: 'inherit' })
-				.on('close', (exitCode: number) => {
-					if (exitCode) {
-						fail('Tests did not complete successfully');
-					}
-					else {
-						succeed();
-					}
-				})
-				.on('error', (err: Error) => {
-					fail(err.message);
-				});
-		}
-		else {
-			cs.spawn(path.resolve('node_modules/.bin/intern-client'), parseArguments(testArgs), { stdio: 'inherit' })
-				.on('close', (exitCode: number) => {
-					if (exitCode) {
-						fail('Tests did not complete successfully');
-					}
-					else {
-						succeed();
-					}
-				})
-				.on('error', (err: Error) => {
-					fail(err.message);
-				});
-		}
+		cs.spawn(path.resolve(`node_modules/.bin/${shouldRunInBrowser(testArgs) ? 'intern-runner' : 'intern-client'}`), parseArguments(testArgs), { stdio: 'inherit' })
+			.on('close', (exitCode: number) => {
+				if (exitCode) {
+					fail('Tests did not complete successfully');
+				}
+				else {
+					succeed();
+				}
+			})
+			.on('error', (err: Error) => {
+				fail(err.message);
+			});
 	});
 }

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -10,10 +10,11 @@ const packagePath = pkgDir.sync(dirname);
 const process = require('process');
 const projectName = require(path.join(process.cwd(), './package.json')).name;
 
-export function parseArguments({ unit, functional, config, coverage, reporters, testingKey, secret, userName }: TestArgs) {
+export function parseArguments({ all, unit, functional, config, coverage, reporters, testingKey, secret, userName }: TestArgs) {
 	const configArg = config ? `-${config}` : '';
 	const args = [ `config=${path.relative('.', path.join(packagePath, 'intern', 'intern' + configArg))}` ];
-	if (unit) {
+
+	if (!all && unit) {
 		args.push('functionalSuites=');
 	}
 	else if (functional) {
@@ -51,6 +52,10 @@ export function parseArguments({ unit, functional, config, coverage, reporters, 
 	return [ ...args ];
 }
 
+function shouldRunInBrowser(args: TestArgs) {
+	return args.browser || args.functional || args.all;
+}
+
 export default async function (testArgs: TestArgs) {
 	return new Promise((resolve, reject) => {
 		const spinner = ora({
@@ -72,17 +77,33 @@ export default async function (testArgs: TestArgs) {
 			});
 		}
 
-		cs.spawn(path.resolve('node_modules/.bin/intern-runner'), parseArguments(testArgs), { stdio: 'inherit' })
-			.on('close', (exitCode: number) => {
-				if (exitCode) {
-					fail('Tests did not complete successfully');
-				}
-				else {
-					succeed();
-				}
-			})
-			.on('error', (err: Error) => {
-				fail(err.message);
-			});
+		if (shouldRunInBrowser(testArgs)) {
+			cs.spawn(path.resolve('node_modules/.bin/intern-runner'), parseArguments(testArgs), { stdio: 'inherit' })
+				.on('close', (exitCode: number) => {
+					if (exitCode) {
+						fail('Tests did not complete successfully');
+					}
+					else {
+						succeed();
+					}
+				})
+				.on('error', (err: Error) => {
+					fail(err.message);
+				});
+		}
+		else {
+			cs.spawn(path.resolve('node_modules/.bin/intern-client'), parseArguments(testArgs), { stdio: 'inherit' })
+				.on('close', (exitCode: number) => {
+					if (exitCode) {
+						fail('Tests did not complete successfully');
+					}
+					else {
+						succeed();
+					}
+				})
+				.on('error', (err: Error) => {
+					fail(err.message);
+				});
+		}
 	});
 }

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,9 +1,9 @@
 import { beforeEach, afterEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
 import * as mockery from 'mockery';
+import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
 import { throwImmediatly } from '../support/util';
-import * as sinon from 'sinon';
 
 describe('main', () => {
 
@@ -31,53 +31,30 @@ describe('main', () => {
 	it('should register supported arguments', () => {
 		const options = sandbox.stub();
 		moduleUnderTest.register(options);
-		assert.deepEqual(
-			options.firstCall.args,
-			[ 'c', { alias: 'config', describe: 'Specifies what configuration to test with: \'local\'(default), \'browserstack\', \'testingbot\', or \'saucelabs\'.', type: 'string' } ],
-			'First argument'
-		);
 
-		assert.deepEqual(
-			options.secondCall.args,
-			[ 'r', { alias: 'reporters', describe: 'Comma separated list of reporters to use, defaults to Console', type: 'string' }],
-			'Third argument'
-		);
+		let untestedArguments: { [key: string]: string } = {
+			'a': 'all',
+			'b': 'browser',
+			'c': 'config',
+			'cov': 'coverage',
+			'f': 'functional',
+			'k': 'testingKey',
+			'n': 'userName',
+			'r': 'reporters',
+			's': 'secret',
+			'u': 'unit'
+		};
 
-		assert.deepEqual(
-			options.thirdCall.args,
-			[ 'u', { alias: 'unit', describe: 'Indicates that only unit tests should be run. By default functional tests and unit tests are run' }],
-			'Fourth argument'
-		);
+		for (let i = 0; i < options.callCount; i++) {
+			const call = options.getCall(i);
 
-		assert.deepEqual(
-			options.getCall(3).args,
-			[ 'f', { alias: 'functional', describe: 'Indicates that only functional tests should be run. By default functional tests and unit tests are run' }],
-			'Fifth argument'
-		);
+			assert.isTrue(call.args[ 0 ] in untestedArguments);
+			assert.strictEqual(call.args[ 1 ].alias, untestedArguments[ call.args[ 0 ] ]);
 
-		assert.deepEqual(
-			options.getCall(4).args,
-			[ 'cov', { alias: 'coverage', describe: 'If specified coverage will be included. This is the same as adding the LcovHtml reporter' }],
-			'Sixth argument'
-		);
+			delete untestedArguments[ call.args[ 0 ] ];
+		}
 
-		assert.deepEqual(
-			options.getCall(5).args,
-			[ 'k', { alias: 'testingKey', describe: 'API key for testingbot or accesskey for saucelabs or browserstack', type: 'string' }],
-			'Seventh Argument'
-		);
-
-		assert.deepEqual(
-			options.getCall(6).args,
-			[ 'n', { alias: 'userName', describe: 'User name for testing platform', type: 'string' }],
-			'Eigth Argument'
-		);
-
-		assert.deepEqual(
-			options.getCall(7).args,
-			[ 's', { alias: 'secret', describe: 'API secret for testingbot', type: 'string' }],
-			'Ninth Argument'
-		);
+		assert.isTrue(Object.keys(untestedArguments).length === 0, 'Not all commands are tested');
 	});
 
 	it('should check for build command and fail if it doesn\'t exist', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR will make `dojo test` behave more like `grunt test`.

Updates:

* By default, it will only run the unit tests in node
* You can now choose to run the unit tests (browser or node), and/or the functional tests (browser only). If you run the functional tests, the unit tests *will run in the browser*.

Usage:

```bash
# Run unit tests in node
$ dojo test

# Run unit tests in a browser
$ dojo test -b

# Run all the tests in a browser
$ dojo test -a

# Run only the functional tests
$ dojo test -f
```

Resolves #3 
