### PR TITLE
Adding eject command, issue #4

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,28 @@ const command: Command = {
 				reject
 			);
 		});
+	},
+	eject(helper: Helper) {
+		return {
+			npm: {
+				devDependencies: {
+					'intern': '~3.4.2',
+					'istanbul': '^0.4.3',
+					'mockery': '^1.7.0',
+					'remap-istanbul': '^0.6.4',
+					'sinon': '^1.17.5'
+				}
+			},
+			copy: {
+				path: __dirname + '/intern',
+				files: [
+					'./intern.js',
+					'./intern-browserstack.js',
+					'./intern-saucelabs.js',
+					'./intern-testingbot.js'
+				]
+			}
+		};
 	}
 };
 export default command;

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,9 +1,9 @@
 import { beforeEach, afterEach, describe, it } from 'intern!bdd';
 import * as assert from 'intern/chai!assert';
 import * as mockery from 'mockery';
+import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
 import { throwImmediatly } from '../support/util';
-import * as sinon from 'sinon';
 
 describe('main', () => {
 
@@ -128,5 +128,13 @@ describe('main', () => {
 			}
 		);
 
+	});
+
+	it('should support eject', () => {
+		const result = moduleUnderTest.eject();
+
+		assert.isTrue('npm' in result, 'Should have returned npm dependencies');
+		assert.isTrue('copy' in result, 'Should have returned a list of files to copy');
+		assert.isTrue('files' in result.copy, 'Should have returned a list of files to copy');
 	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding support for cli's `eject` command.  When ejecting the tests, you get:

* Intern config files for local, browser stack, saucelabs, and testingbot.
* `devDependencies` for intern, istanbul, remap-instanbul, mockery, and sinon.

_Note: Tested on kitchen-sink and successfully manually ran the tests after ejecting the command._

Resolves #4 
