### PR TITLE
Pass the new `target` option to the builder to create proper Webpack chunks.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -97,7 +97,7 @@ const command: Command = {
 			if (!helper.command.exists('build')) {
 				reject(Error('Required command: \'build\', does not exist. Have you run npm install @dojo/cli-build?'));
 			}
-			const result = helper.command.run('build', '', <any> { withTests: true });
+			const result = helper.command.run('build', '', <any> { withTests: true, target: args.browser ? 'web' : 'node' });
 			result.then(
 				() => {
 					runTests(args).then(resolve, reject);

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -85,9 +85,24 @@ describe('main', () => {
 		const runTestArgs = { testArg: 'value' };
 		return moduleUnderTest.run(helper, runTestArgs).then(() => {
 			assert.isTrue(helper.command.run.calledOnce, 'Should have called run');
-			assert.deepEqual(helper.command.run.firstCall.args, [ 'build', '', { withTests: true } ], 'Didn\'t call with proper arguments');
+			assert.deepEqual(helper.command.run.firstCall.args, [ 'build', '', { withTests: true, target: 'node' } ],
+				'Didn\'t call with proper arguments');
 			assert.isTrue(mockRunTests.default.calledOnce, 'Should have called the runTests module');
 			assert.deepEqual(mockRunTests.default.firstCall.args, [ runTestArgs ], 'Didn\'t run tests with provided arguments');
+		});
+	});
+
+	it('should run the build command with web target', () => {
+		const helper = {
+			command: {
+				exists: sandbox.stub().returns(true),
+				run: sandbox.stub().returns(Promise.resolve())
+			}
+		};
+		const runTestArgs = { testArg: 'value', browser: true };
+		return moduleUnderTest.run(helper, runTestArgs).then(() => {
+			assert.deepEqual(helper.command.run.firstCall.args, [ 'build', '', { withTests: true, target: 'web' } ],
+				'Didn\'t call with proper arguments');
 		});
 	});
 
@@ -103,7 +118,8 @@ describe('main', () => {
 			throwImmediatly,
 			(error: any) => {
 				assert.isTrue(helper.command.run.calledOnce, 'Should have called run');
-				assert.deepEqual(helper.command.run.firstCall.args, [ 'build', '', { withTests: true } ], 'Didn\'t call with proper arguments');
+				assert.deepEqual(helper.command.run.firstCall.args, [ 'build', '', { withTests: true, target: 'node' } ],
+					'Didn\'t call with proper arguments');
 				assert.equal('Failed to build', error.message, 'Wrong error message');
 			}
 		);


### PR DESCRIPTION
The Webpack chunks need to be built for the correct environment.  They are currently always being targeted for the browser.  This update passes the new `target` option to the build tool.  `target` is set to "node" by default and "web" when the `browser` option is passed to `dojo test`. 

Fix dojo/cli-test-intern#17

This is fix 2 of 2 for dojo/cli-test-intern#17. The first fix is in dojo\cli-build.