### PR TITLE
include loadJsDom in the suites packages

### DIFF
--- a/src/intern/intern.js
+++ b/src/intern/intern.js
@@ -49,7 +49,7 @@ define({
 	},
 
 	// Non-functional test suite(s) to run in each browser
-	suites: [ 'tests/unit/all' ],
+	suites: [ '@dojo/test-extras/support/loadJsdom', 'tests/unit/all' ],
 
 	// Functional test suite(s) to run in each browser once non-functional tests are completed
 	functionalSuites: [ 'tests/functional/all' ],


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Include `loadJsdom` by default in the intern.js suites.

Resolves #33
