### PR TITLE
Add path to Intern browser runner

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -135,6 +135,7 @@ const command: Command = {
 				() => {
 					runTests(args)
 						.then(() => {
+							console.log('\n to run in browser: ' + underline('./node_modules/intern/client.html?config=node_modules/@dojo/cli-test-intern/intern/intern'));
 							process.removeListener('unhandledRejection', unhandledRejection);
 						})
 						.then(resolve, reject);

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -165,15 +165,16 @@ describe('main', () => {
 				exists: sandbox.stub().returns(true),
 				run() {
 					Promise.reject(new Error('foo'));
-					return Promise.resolve();
 				}
 			}
 		};
 
-		const count = consoleStub.callCount;
+		moduleUnderTest.run(<any> helper, <any> {});
 
-		return moduleUnderTest.run(<any> helper, <any> {}).then(() => {
-			assert.strictEqual(consoleStub.callCount, count + 1, 'call count');
+		return new Promise((resolve) => {
+			setTimeout(resolve, 10);
+		}).then(() => {
+			assert.isTrue(consoleStub.calledWith('Unhandled Promise Rejection: '));
 		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

**Description:**

Adds a link to the browser runner on successful build.
