### PR TITLE
Include dojo/test-extras dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "yargs": "^5.0.0"
   },
   "dependencies": {
+    "@dojo/test-extras": "^2.0.0-alpha.1",
     "chalk": "^1.1.3",
     "codecov.io": "0.1.6",
     "cross-spawn": "^4.0.0",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The `@dojo/test-extras` should be bundled.