### PR TITLE
Increase test timeout

### DIFF
--- a/src/intern/intern.js
+++ b/src/intern/intern.js
@@ -57,5 +57,5 @@ define({
 	// A regular expression matching URLs to files that should not be included in code coverage analysis
 	excludeInstrumentation: /(?:node_modules|_build\/src)[\/]/,
 
-	defaultTimeout: 5000
+	defaultTimeout: 15000
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

It makes sense to increase the timeout, tests on browser stack on IE11 are failing due to hitting the timeout (currently 5 seconds).

Updated to 15 seconds.