### PR TITLE
Turn `projectName` into a function

### DIFF
--- a/src/dirname.ts
+++ b/src/dirname.ts
@@ -1,1 +1,7 @@
+import * as path from 'path';
+
 export default __dirname;
+
+export function projectName() {
+	return require(path.join(process.cwd(), './package.json')).name;
+}

--- a/src/remapCoverage.ts
+++ b/src/remapCoverage.ts
@@ -4,9 +4,9 @@ import * as path from 'path';
 import * as MemoryStore from 'istanbul/lib/store/memory';
 import { loadCoverage, remap, writeReport } from 'remap-istanbul/lib/main';
 import { TestArgs } from './main';
+import { projectName } from './dirname';
 
 const process: NodeJS.Process = require('process');
-const projectName = require(path.join(process.cwd(), './package.json')).name;
 
 /**
  * Returns true for files that should be remapped.
@@ -72,7 +72,7 @@ export default async function remapCoverage(testArgs: TestArgs) {
 		unlinkSync('coverage-final.json');
 
 		const reports = [ (() => {
-			console.log('\n' + underline(`code coverage for "${projectName}"...`) + '\n');
+			console.log('\n' + underline(`code coverage for "${projectName()}"...`) + '\n');
 			return writeReport(collector, 'text', {}, null, sources);
 		})() ];
 

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -1,13 +1,12 @@
 import * as path from 'path';
 import { blue, green, red, underline } from 'chalk';
-import dirname from './dirname';
+import dirname, { projectName } from './dirname';
 import { TestArgs } from './main';
 import remapCoverage from './remapCoverage';
 
 const cs: any = require('cross-spawn');
 const pkgDir: any = require('pkg-dir');
 const packagePath = pkgDir.sync(dirname);
-const projectName = require(path.join(process.cwd(), './package.json')).name;
 /* Custom reporter used for reporting */
 const internReporter = path.join(packagePath, 'reporters', 'Reporter');
 
@@ -38,7 +37,7 @@ export function parseArguments({ all, config, functional, internConfig, reporter
 		args.push(`tunnelOptions={ "username": "${userName}", "accessKey": "${testingKey}" }`);
 	}
 
-	const capabilitiesBase = `capabilities={ "name": "${projectName}", "project": "${projectName}"`;
+	const capabilitiesBase = `capabilities={ "name": "${projectName()}", "project": "${projectName()}"`;
 	if (config === 'browserstack') {
 		args.push(capabilitiesBase + ', "fixSessionCapabilities": "false", "browserstack.debug": "false" }');
 	}
@@ -75,7 +74,7 @@ export default async function (testArgs: TestArgs) {
 			});
 		}
 
-		logger('\n' + underline(`testing "${projectName}"...`) + `\n`);
+		logger('\n' + underline(`testing "${projectName()}"...`) + `\n`);
 
 		if (testArgs.verbose) {
 			logger(`${blue.bold('  Parsed arguments for intern:')}`);


### PR DESCRIPTION
**Type:** bug fix

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR turns `projectName` into a function so it can be called at run time when `test` command is actually used, rather than at initialization time when `test` command is loaded.

Resolves #43 
