### PR TITLE
Update to TypeScript 2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
     "pkg-dir": "^1.0.0",
     "remap-istanbul": "^0.9.5",
     "sinon": "^1.17.5",
-    "typescript": "~2.2.1"
+    "typescript": "~2.4.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,13 +3,11 @@
 		"declaration": false,
 		"module": "umd",
 		"moduleResolution": "node",
-		"noImplicitAny": true,
-		"noImplicitThis": true,
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
-		"strictNullChecks": true,
-		"target": "es6",
+		"strict": true,
+		"target": "es2016",
 		"types": [ "intern" ]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR updates the package to TypeScript 2.4 and migrates to the `strict` compiler flag.

Refs: dojo/meta#189
