### PR TITLE
update parseArguments to use `intern-local` as default configuration

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -13,7 +13,7 @@ const internReporter = `${path.relative(process.cwd(), packagePath)}/reporters/R
 let logger = console.log;
 
 export function parseArguments({ all, config, functional, internConfig, reporters, secret, testingKey, unit, userName }: TestArgs) {
-	const configArg = config ? `-${config}` : '';
+	const configArg = config ? `-${config}` : '-local';
 	const args = [
 		internConfig
 			? `config=${path.relative(process.cwd(), internConfig)}`

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -44,4 +44,4 @@ export const loaderOptions = {
 export const suites = [ 'tests/unit/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]|intern\.js|intern-browserstack\.js|intern-saucelabs\.js|intern-testingbot\.js|dirname/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests)[\/\\]|intern-local\.js|intern-browserstack\.js|intern-saucelabs\.js|intern-testingbot\.js|dirname/;

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -126,7 +126,7 @@ describe('runTests', () => {
 		});
 
 		it('Should have a default for intern config', () => {
-			assert.equal(runTests.parseArguments({})[0], path.join('config=intern', 'intern'));
+			assert.equal(runTests.parseArguments({})[0], path.join('config=intern', 'intern-local'));
 		});
 
 		it('Should push an empty functionalSuites arg if unit is provided', () => {


### PR DESCRIPTION
A [recent commit](https://github.com/dojo/cli-test-intern/commit/03ab00cea843ebb9eebd93afbd434b839cc671bb) changed the name of the default configuration file from `intern` to `intern-local`, but the `runTests` module was not updated to use the new file name. This PR updates that file and the associated tests to use `intern-local` as the default test configuration.