### PR TITLE
Loading from intern-local instead of intern

### DIFF
--- a/src/intern/intern-browserstack.js
+++ b/src/intern/intern-browserstack.js
@@ -1,5 +1,5 @@
 define([
-	'./intern'
+	'./intern-local'
 ], function (intern) {
 	intern.tunnel = 'BrowserStackTunnel';
 	intern.tunnelOptions = {};

--- a/src/intern/intern-saucelabs.js
+++ b/src/intern/intern-saucelabs.js
@@ -1,5 +1,5 @@
 define([
-	'./intern'
+	'./intern-local'
 ], function (intern) {
 
 	intern.environments = [

--- a/src/intern/intern-testingbot.js
+++ b/src/intern/intern-testingbot.js
@@ -1,5 +1,5 @@
 define([
-	'./intern'
+	'./intern-local'
 ], function (intern) {
 
 	intern.environments = [


### PR DESCRIPTION
**Type:** bug

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The configuration files were importing a file called `./intern` but that file was renamed to `./intern-local`.