### PR TITLE
Migrate to @dojo/interfaces/cli and @types

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test": "grunt test"
   },
   "devDependencies": {
+    "@dojo/interfaces": "next",
     "@dojo/loader": "next",
     "@types/chalk": "^0.4.31",
     "@types/charm": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "@dojo/cli": "next",
     "@dojo/loader": "next",
     "@types/chalk": "^0.4.31",
     "@types/charm": "^1.0.0",
@@ -30,6 +29,7 @@
     "@types/mockery": "^1.4.29",
     "@types/sinon": "^1.16.35",
     "@types/source-map": "^0.5.0",
+    "@types/yargs": "^8.0.2",
     "glob": "^7.0.3",
     "grunt": "~1.0.1",
     "grunt-dojo2": "latest",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,14 +1,13 @@
-import { Command, Helper, OptionsHelper } from '@dojo/cli/interfaces';
+import { Command, Helper, OptionsHelper } from '@dojo/interfaces/cli';
 import { underline } from 'chalk';
 import * as path from 'path';
-import { Argv } from 'yargs';
 import runTests from './runTests';
 
 const pkgDir = require('pkg-dir');
 
 const CLI_BUILD_PACKAGE = '@dojo/cli-build-webpack';
 
-export interface TestArgs extends Argv {
+export interface TestArgs {
 	all: boolean;
 	browser?: boolean;
 	config?: string;
@@ -21,6 +20,7 @@ export interface TestArgs extends Argv {
 	userName?: string;
 	unit: boolean;
 	verbose: boolean;
+	internConfig: string;
 }
 
 function buildNpmDependencies(): any {
@@ -36,7 +36,7 @@ function buildNpmDependencies(): any {
 	}
 }
 
-const command: Command = {
+const command: Command<TestArgs> = {
 	description: 'this command will implicitly build your application and then run tests against that build',
 	register(options: OptionsHelper) {
 		options('a', {

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -5,7 +5,7 @@ import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
 import { throwImmediatly } from '../support/util';
-import { Command } from '@dojo/cli/interfaces';
+import { Command } from '@dojo/interfaces/cli';
 
 describe('main', () => {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
 		"types": [ "intern" ]
 	},
 	"include": [
-		"./typings/index.d.ts",
 		"./src/**/*.ts",
 		"./tests/**/*.ts"
 	]

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,0 @@
-{
-	"name": "dojo-cli-test-intern",
-	"dependencies": {
-		"yargs": "registry:npm/yargs#5.0.0+20160907000723"
-	}
-}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Migrate to use `@dojo/interfaces/cli` and `@types` for other typings.

Depends on a release of `@dojo/interfaces`.

Refs: https://github.com/dojo/cli/issues/119