### PR TITLE
Add code that looks for the existence of a Java VM when it is needed.

### DIFF
--- a/src/javaCheck.ts
+++ b/src/javaCheck.ts
@@ -1,0 +1,23 @@
+const { exec } = require('child_process');
+import { TestArgs } from './main';
+
+function requiresTunnel(args: TestArgs) {
+	const { all, functional, config } = args;
+	return all || functional || ( config != null && config !== 'local');
+}
+
+function containsVersionString(str: string): boolean {
+	return str != null && str.indexOf('java version') >= 0;
+}
+
+export default function (args: TestArgs) {
+	return new Promise<boolean>((resolve) => {
+		if (!requiresTunnel(args)) {
+			resolve(true);
+		} else {
+			exec('java -version', (err: Error, stdout: string, stderr: string) => {
+				resolve(!err && (containsVersionString(stderr) || containsVersionString(stdout)));
+			});
+		}
+	});
+}

--- a/src/javaCheck.ts
+++ b/src/javaCheck.ts
@@ -19,7 +19,7 @@ export default function (args: TestArgs) {
 				if (!err && (containsVersionString(stderr) || containsVersionString(stdout))) {
 					resolve(true);
 				} else {
-					// De-reference the environment variables here so the exec script does not have to use
+					// Dereference the environment variables here so the exec script does not have to use
 					// an operating system specific way to dereference an environment variable.
 					const javaHome = process.env.JAVA_HOME || process.env.JDK_HOME || process.env.JRE_HOME;
 					if (javaHome) {

--- a/src/javaCheck.ts
+++ b/src/javaCheck.ts
@@ -16,7 +16,20 @@ export default function (args: TestArgs) {
 			resolve(true);
 		} else {
 			exec('java -version', (err: Error, stdout: string, stderr: string) => {
-				resolve(!err && (containsVersionString(stderr) || containsVersionString(stdout)));
+				if (!err && (containsVersionString(stderr) || containsVersionString(stdout))) {
+					resolve(true);
+				} else {
+					// De-reference the environment variables here so the exec script does not have to use
+					// an operating system specific way to dereference an environment variable.
+					const javaHome = process.env.JAVA_HOME || process.env.JDK_HOME || process.env.JRE_HOME;
+					if (javaHome) {
+						exec(`"${javaHome}/bin/java" -version`, (err: Error, stdout: string, stderr: string) => {
+							resolve(!err && (containsVersionString(stderr) || containsVersionString(stdout)));
+						});
+					} else {
+						resolve(false);
+					}
+				}
 			});
 		}
 	});

--- a/src/main.ts
+++ b/src/main.ts
@@ -88,7 +88,7 @@ const command: Command<TestArgs> = {
 		options('a', {
 			alias: 'all',
 			describe: 'Runs unit tests and functional tests. Unit tests are run via node and the local tunnel. Functional tests are run via the local tunnel',
-			'default': false
+			default: false
 		});
 
 		options('c', {
@@ -105,7 +105,7 @@ const command: Command<TestArgs> = {
 		options('f', {
 			alias: 'functional',
 			describe: 'Runs only functional tests. Tests are run via the local tunnel',
-			'default': false
+			default: false
 		});
 
 		options('k', {
@@ -124,7 +124,7 @@ const command: Command<TestArgs> = {
 			alias: 'output',
 			describe: `The path to output any test output to (e.g. coverage information). Defaults to './output/tests'`,
 			type: 'string',
-			'default': './output/tests'
+			default: './output/tests'
 		});
 
 		options('r', {
@@ -142,20 +142,20 @@ const command: Command<TestArgs> = {
 		options('u', {
 			alias: 'unit',
 			describe: 'Runs unit tests via node and the local tunnel',
-			'default': false
+			default: false
 		});
 
 		options('v', {
 			alias: 'verbose',
 			describe: 'Produce diagnostic messages to the console.',
-			'default': false
+			default: false
 		});
 
 		options('n', {
 			alias: 'node',
 			describe: 'Run unit tests via node',
 			type: 'boolean',
-			'default': true
+			default: true
 		});
 
 		options('filter', {

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -13,6 +13,6 @@ export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean>
 	});
 }
 
-export function throwImmediatly() {
+export function throwImmediately() {
 	throw new Error('unexpected code path');
 }

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -1,2 +1,3 @@
 import './main';
 import './runTests';
+import './javaCheck';

--- a/tests/unit/javaCheck.ts
+++ b/tests/unit/javaCheck.ts
@@ -1,0 +1,138 @@
+import * as mockery from 'mockery';
+import { TestArgs } from '../../src/main';
+
+const { before, after, beforeEach, describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+const javaVersionString = 'Some java version in here';
+
+describe('javaCheck', () => {
+	let javaCheck: (args: TestArgs) => Promise<boolean>;
+
+	let args: TestArgs;
+
+	let execError: Error | undefined;
+	let execStdout: string | undefined;
+	let execStderr: string | undefined;
+
+	before(() => {
+		// Use mockery to replace child_process to the actuall call to the java VM does not occur.
+		mockery.enable({
+			warnOnUnregistered: false,
+			useCleanCache: true
+		});
+		mockery.registerMock('child_process', {
+			exec: function (command: string, callback: (err?: Error, stdout?: string, stderr?: string) => void) {
+				callback(execError, execStdout, execStderr);
+			}
+		});
+
+		// javaCheck has to be loaded AFTER the mock is setup.
+		javaCheck = require('../../src/javaCheck').default;
+	});
+
+	beforeEach(() => {
+		args = {
+			all: false,
+			browser: false,
+			functional: false,
+			unit: false,
+			verbose: false,
+			internConfig: '',
+			node: false,
+			filter: ''
+		};
+
+		execError = undefined;
+		execStdout = undefined;
+		execStderr = undefined;
+	});
+
+	const javaNeeded = [ 'all', 'functional' ];
+	const javaNotNeeded = [ 'browser', 'unit', 'node' ];
+
+	javaNeeded.forEach(function (property) {
+		it(`should require java with "${property}" and fail when there is none`, () => {
+			(<any> args)[ property ] = true;
+			return javaCheck(args).then((passed: boolean) => {
+				assert.isFalse(passed, `"${property}" failed`);
+			});
+		});
+	});
+
+	javaNeeded.forEach(function (property) {
+		it(`should require java with "${property}" and fail when an error occurs`, () => {
+			(<any> args)[ property ] = true;
+			execStderr = javaVersionString;
+			execStdout = javaVersionString;
+			execError = new Error('something bad');
+			return javaCheck(args).then((passed: boolean) => {
+				assert.isFalse(passed, `"${property}" failed`);
+			});
+		});
+	});
+
+	javaNotNeeded.forEach(function (property) {
+		it(`should not require java with "${property}"`, () => {
+			(<any> args)[ property ] = true;
+			return javaCheck(args).then((passed: boolean) => {
+				assert.isTrue(passed, `"${property}" failed`);
+			});
+		});
+	});
+
+	javaNeeded.forEach(function (property) {
+		it(`should require java with "${property}" and pass when stderr contains the version`, () => {
+			(<any> args)[ property ] = true;
+			execStderr = javaVersionString;
+			return javaCheck(args).then((passed: boolean) => {
+				assert.isTrue(passed, `"${property}" failed`);
+			});
+		});
+	});
+
+	javaNeeded.forEach(function (property) {
+		it(`should require java with "${property}" and pass when stdout contains the version`, () => {
+			(<any> args)[ property ] = true;
+			execStdout = javaVersionString;
+			return javaCheck(args).then((passed: boolean) => {
+				assert.isTrue(passed, `"${property}" failed`);
+			});
+		});
+	});
+
+	it('should require java with config set to browserstack and fail when it is not available', () => {
+		args.config = 'browserstack';
+		return javaCheck(args).then((passed: boolean) => {
+			assert.isFalse(passed);
+		});
+	});
+
+	it('should require java with config set to browserstack and pass when avaiable via stdout', () => {
+		args.config = 'browserstack';
+		execStdout = 'Some java version exists';
+		return javaCheck(args).then((passed: boolean) => {
+			assert.isTrue(passed);
+		});
+	});
+
+	it('should require java with config set to browserstack and pass when avaiable via stderr', () => {
+		args.config = 'browserstack';
+		execStderr = 'Some java version exists';
+		return javaCheck(args).then((passed: boolean) => {
+			assert.isTrue(passed);
+		});
+	});
+
+	it('should not require java with config set to local', () => {
+		args.config = 'local';
+		return javaCheck(args).then((passed: boolean) => {
+			assert.isTrue(passed);
+		});
+	});
+
+	after(() => {
+		mockery.deregisterAll();
+		mockery.disable();
+	});
+});

--- a/tests/unit/javaCheck.ts
+++ b/tests/unit/javaCheck.ts
@@ -101,6 +101,17 @@ describe('javaCheck', () => {
 		});
 	});
 
+	it('should fail if no java environment variables are set', () => {
+		args.all = true;
+		const origEnv = process.env;
+		process.env = {};
+		return javaCheck(args).then((passed: boolean) => {
+			assert.isFalse(passed);
+		}).then(() => {
+			process.env = origEnv;
+		});
+	});
+
 	it('should require java with config set to browserstack and fail when it is not available', () => {
 		args.config = 'browserstack';
 		return javaCheck(args).then((passed: boolean) => {


### PR DESCRIPTION
If a user runs `dojo test` with an option that needs a Selenium tunnel, the cli-test-intern command will check to see if a Java VM has been installed.  If not, the user will see:

> Error! Java VM could not be found.
> A Java VM needs to be installed and available from the command line to allow the dojo test command to run tests in a browser locally or remotely.

When Java has not been installed on Mac OSX, a user will see the message above but will also see a popup dialog telling the user that Java was requested.  The popup is part of the Mac OS and gives the user information on how to install Java.

This PR includes updated to the test command as well as unit tests that cover the new functionality.

Fixes #51 