### PR TITLE
Use cwd for basePath

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -44,6 +44,8 @@ export function parseArguments(testArgs: TestOptions) {
 			: `config=${path.relative(process.cwd(), path.join(packagePath, 'intern', 'intern.json' + configArg))}`
 	];
 
+	args.push(`basePath=${process.cwd()}`);
+
 	// by default, in the intern config, all tests are run. we need to
 	// disable tests that we dont want to run
 	if (!remoteUnit && !nodeUnit) {

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -216,5 +216,10 @@ describe('runTests', () => {
 				'Didn\'t add default config config'
 			);
 		});
+
+		it('Should pass the basePath as the current working directory', async () => {
+			const args = runTests.parseArguments({});
+			assert.include(args, `basePath=${process.cwd()}`);
+		});
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
In intern 4.1.0 it tries to resolve the `basePath` to where the `intern.json` is located, which is unfortunate as that is not the project root for projects using `cli-test-intern`. For now, set the `basePath` as the cwd, which should be the project root.

Resolves https://github.com/dojo/cli-test-intern/issues/79
