### PR TITLE
Support cli-build-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ The official Dojo 2 test command.
 
 ## Features
 
-Builds and runs test cases for a Dojo 2 application. This module assumes that your project is structured
-as it would be if created by `dojo create`. Specifically, `src` and `tests` should be in the root of the project directory,
-and `tests` should have `functional` and `unit` folders with `all.ts` files in each that import other tests.
+Runs tests built using `@dojo/cli-build-webpack`, or `@dojo/cli-build-app`.
+
 
 ## How do I use this package?
 
@@ -27,7 +26,7 @@ Contributing Guidelines and Style Guide.
 
 ## Testing
 
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
+Test cases MUST be written using [Intern](https://theintern.github.io) using the bdd test interface and Assert assertion interface.
 
 90% branch coverage MUST be provided for all code submitted to this repository, as reported by Istanbul’s combined coverage results for all supported platforms.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,41 @@
 {
   "name": "@dojo/cli-test-intern",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@dojo/core": {
       "version": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
-      "integrity": "sha1-GZWgiFdMNqX5G8t/PtBNGwS7dfQ="
+      "integrity": "sha512-SnmiQcbPUqtjzy1sOmkLvg3C6UFUaXDNUNqHzGaF2QM1Ebp1Lw+j+BE+E6uJgxISlgckjAZ6myjwFI+obZ316w=="
     },
     "@dojo/has": {
       "version": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-      "integrity": "sha1-ng8lL+IbZaNkBo23ImyiVczu5G8="
+      "integrity": "sha512-McwwBLpM0R0zsIy0+1WkHFXYYNalMOPJydqW3dd089K+AaOCto4AtFKA6+GDEuXDgJE9cMG5tX48hFwIL3dtxQ=="
     },
     "@dojo/i18n": {
       "version": "https://registry.npmjs.org/@dojo/i18n/-/i18n-0.3.0.tgz",
-      "integrity": "sha1-ko/Ken3FUnrsd3qE7I+h0a/WjdU=",
+      "integrity": "sha512-Tmw+DMU/umWPtoCbfNmo7WdsoD/5jhyUcoq++mq0ywlta/AzC6bUtUvKa5LAgpaEk7kioQwd9zHnP7hGecrxIw==",
       "requires": {
         "globalize": "https://registry.npmjs.org/globalize/-/globalize-1.3.0.tgz"
       }
     },
     "@dojo/interfaces": {
-      "version": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
-      "integrity": "sha1-lXpOAk/v5tF6HkzVczrwhn77MmM=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
+      "dev": true,
       "requires": {
-        "@types/yargs": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
       "version": "https://registry.npmjs.org/@dojo/loader/-/loader-0.1.1.tgz",
-      "integrity": "sha1-KgEoy+Rc7S7Wt6gn8f0Zg390LN8=",
+      "integrity": "sha512-DRfG8tCaV1kJdFHxN+qW3KY2clVna/Y5f5aXfG5gOxY7JDwqvQ+ooU8xtKY4Ob53FH0yOUFKMbiiIMbgyCWyrA==",
       "dev": true
     },
     "@dojo/shim": {
       "version": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-      "integrity": "sha1-ox/CjjWyrDMjJyzAOm62ctq8T3I=",
+      "integrity": "sha512-DzpD1D90D1vsHuqPqGb78JFfykf0Nvbel+iAupYVPEwq+LVxAZPDC8nGZRsAaVfWSsFLuKPcbRRIInf+emCFAw==",
       "requires": {
         "intersection-observer": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
         "pepjs": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
@@ -42,7 +44,7 @@
     },
     "@dojo/test-extras": {
       "version": "https://registry.npmjs.org/@dojo/test-extras/-/test-extras-0.3.0.tgz",
-      "integrity": "sha1-8vZqylFyiYqPAeuT8TnnfS6jkuo=",
+      "integrity": "sha512-O9D4VyTvQ2kYH0MnmEUkfFvR9r1DRuZGkrWMpZBb0bYaIIWlSfCIXjuujb+KvU5hxKKQpq/TRddappGW5Oz0Fg==",
       "requires": {
         "jsdom": "https://registry.npmjs.org/jsdom/-/jsdom-10.1.0.tgz",
         "pepjs": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz"
@@ -50,7 +52,7 @@
     },
     "@dojo/widget-core": {
       "version": "https://registry.npmjs.org/@dojo/widget-core/-/widget-core-0.4.0.tgz",
-      "integrity": "sha1-+rFeq8Rj8pysFgN5EQXYhrlLFd8=",
+      "integrity": "sha512-Djh8gcE02AjH29WJO3Z1QYHZwZIVDR4o9cpw5pTpwSdtrAAloE0jnFC6yhQ+tv5feQHVJBEsgUpAUoguXe4qXg==",
       "requires": {
         "intersection-observer": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
         "pepjs": "https://registry.npmjs.org/pepjs/-/pepjs-0.4.3.tgz",
@@ -58,29 +60,71 @@
       }
     },
     "@theintern/digdug": {
-      "version": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
-      "integrity": "sha1-bKkxUOGVf6MdKQbMZO3YKv4JeLQ=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
+      "integrity": "sha512-BTcYNMxOnGlTEaOYqab9WygE2sLz9ZRWRsuTwUttceewzEDn/Ok/4lWdIgwwX+bb3MybvFPU1wBkq8Co+Bfqyw==",
       "requires": {
         "@dojo/core": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
         "@dojo/has": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-        "@dojo/interfaces": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-        "decompress": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+        "decompress": "4.2.0",
         "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-        "tslib": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz"
+        "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "@dojo/interfaces": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+          "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
+          "requires": {
+            "@types/yargs": "8.0.3"
+          }
+        },
+        "@types/yargs": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+          "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w=="
+        },
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+        }
       }
     },
     "@theintern/leadfoot": {
-      "version": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.3.tgz",
-      "integrity": "sha1-dXN5h6Moh4UcVJY5KtypMcdnVWM=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.3.tgz",
+      "integrity": "sha512-J9wLAMjAU+Wyv5jGmHdVN4xnuyaD24kK7mAoLUPBLRNxflkJoTo9Ph5g4BKUHp+xpKd/IMU00ulgMMf++Xqm4A==",
       "requires": {
         "@dojo/core": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
         "@dojo/has": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-        "@dojo/interfaces": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-        "@types/jszip": "https://registry.npmjs.org/@types/jszip/-/jszip-0.0.33.tgz",
-        "jszip": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-        "tslib": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz"
+        "@types/jszip": "0.0.33",
+        "jszip": "3.1.5",
+        "tslib": "1.8.1"
+      },
+      "dependencies": {
+        "@dojo/interfaces": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+          "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
+          "requires": {
+            "@types/yargs": "8.0.3"
+          }
+        },
+        "@types/yargs": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+          "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w=="
+        },
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+        }
       }
     },
     "@types/babel-types": {
@@ -88,20 +132,23 @@
       "integrity": "sha1-XFf0WXPk8TdC28UnPdhM/+c3Op4="
     },
     "@types/benchmark": {
-      "version": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
-      "integrity": "sha1-LdNRTpM5bzYrpVUafJ/w2kBcHTg="
+      "version": "1.0.31",
+      "resolved": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
+      "integrity": "sha512-F6fVNOkGEkSdo/19yWYOwVKGvzbTeWkR/XQYBKtGBQ9oGRjBN9f/L4aJI4sDcVPJO58Y1CJZN8va9V2BhrZapA=="
     },
     "@types/body-parser": {
-      "version": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
-      "integrity": "sha1-aH7DQUBiSjvsKxqOqSaEeK6PO+M=",
+      "version": "1.16.8",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
+      "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
       "requires": {
-        "@types/express": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
+        "@types/express": "4.0.39",
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
       }
     },
     "@types/chai": {
-      "version": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha1-0nYA6bovNx4IaV2QoP4ECNice+c="
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA=="
     },
     "@types/chalk": {
       "version": "https://registry.npmjs.org/@types/chalk/-/chalk-0.4.31.tgz",
@@ -110,22 +157,30 @@
     },
     "@types/charm": {
       "version": "https://registry.npmjs.org/@types/charm/-/charm-1.0.1.tgz",
-      "integrity": "sha1-xGqQZXLlHVoq2TT7oqDQTOh+SQQ=",
+      "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "requires": {
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
       }
     },
     "@types/diff": {
-      "version": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
-      "integrity": "sha1-TW9FU3Mip6Qg01Ogk5UTx+ltFKY="
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
+      "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw=="
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
+      "dev": true
     },
     "@types/express": {
-      "version": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
-      "integrity": "sha1-FEHyHVKzO+jU+oqGXBWmqRzQ+gk=",
+      "version": "4.0.39",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
+      "integrity": "sha512-dBUam7jEjyuEofigUXCtublUHknRZvcRgITlGsTbFgPvnTwtQUt2NgLakbsf+PsGo/Nupqr3IXCYsOpBpofyrA==",
       "requires": {
-        "@types/body-parser": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.16.8.tgz",
+        "@types/body-parser": "1.16.8",
         "@types/express-serve-static-core": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-        "@types/serve-static": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz"
+        "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
@@ -144,17 +199,19 @@
       }
     },
     "@types/glob": {
-      "version": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha1-Pf98bOCdZavpGceWHcPe4Bbzatc=",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.3",
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
       }
     },
     "@types/grunt": {
       "version": "https://registry.npmjs.org/@types/grunt/-/grunt-0.4.22.tgz",
-      "integrity": "sha1-D81kReq3AmRYg+A6tmxAEP8750Q=",
+      "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
@@ -162,65 +219,88 @@
     },
     "@types/handlebars": {
       "version": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-      "integrity": "sha1-/1fHf6GrZxO7RGU03cTZeXB6Onk=",
+      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ==",
       "dev": true
     },
     "@types/highlight.js": {
       "version": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha1-bufNOV7/5eyAtRXT/xaZBozQzR0=",
+      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
       "dev": true
     },
     "@types/http-errors": {
-      "version": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.5.34.tgz",
+      "version": "1.5.34",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.5.34.tgz",
       "integrity": "sha1-1qVvJde5XdBwR2gL+CVjLil5aBU="
     },
     "@types/istanbul-lib-coverage": {
-      "version": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-      "integrity": "sha1-LMLKQQUUmDgrQxV8gif+pgNj+Uo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
+      "integrity": "sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ=="
     },
     "@types/istanbul-lib-hook": {
-      "version": "https://registry.npmjs.org/@types/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz",
-      "integrity": "sha1-YfsNFLEDfEbVS7OVmyXKBV012Gs="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz",
+      "integrity": "sha512-+kdaJ8hO/auIGcqPuSbd3cnTSzgM8ZW0zfYFZLP67vCmWkZV4LdC1XOXpMWnlONup+PChJMK8Q/+Qrh7WoxnUQ=="
     },
     "@types/istanbul-lib-instrument": {
-      "version": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-      "integrity": "sha1-a2I8uQdtRud73gF6iSusqbDepsk=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
+      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
       "requires": {
         "@types/babel-types": "https://registry.npmjs.org/@types/babel-types/-/babel-types-6.25.2.tgz",
-        "@types/istanbul-lib-coverage": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-        "@types/source-map": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "@types/istanbul-lib-report": {
-      "version": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
-      "integrity": "sha1-eem0Y/lH6Y3MgictpRuQj8k+iuo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
+      "integrity": "sha512-nW5QuzmMhr7fHPijtaGOemFFI8Ctrxb/dIXgouSlKmWT16RxWlGLEX/nGghIBOReKe9hPFZXoNh338nFQk2xcA==",
       "requires": {
-        "@types/istanbul-lib-coverage": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz"
+        "@types/istanbul-lib-coverage": "1.1.0"
       }
     },
     "@types/istanbul-lib-source-maps": {
-      "version": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-      "integrity": "sha1-zu6pboyJ7g7vvGxa3ecsVyYR9EI=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.1.tgz",
+      "integrity": "sha512-K0IvmTFbI2GjLG0O4AOLPV2hFItE5Bg/TY41IBZIThhLhYthJc3VjpZpM8/sIaIVtnQcX8b2k3muPDvsvhk+Fg==",
       "requires": {
-        "@types/istanbul-lib-coverage": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-        "@types/source-map": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
       }
     },
     "@types/istanbul-reports": {
-      "version": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
-      "integrity": "sha1-PLPz7oIWDXNdXAZzGKEQxKCgKsk=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
+      "integrity": "sha512-wrJUtE1+HuaRz0Le7fc5l1nMTermRh6wlEvOdQPilseNScyYgQK8MdgDP2cf/X8+6e1dtsX/zP4W4kH/jyHvFw==",
       "requires": {
-        "@types/istanbul-lib-coverage": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-        "@types/istanbul-lib-report": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz"
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "@types/istanbul-lib-report": "1.1.0"
       }
     },
     "@types/jszip": {
-      "version": "https://registry.npmjs.org/@types/jszip/-/jszip-0.0.33.tgz",
-      "integrity": "sha1-AeX4okSqvl8Fsi8TJcS1daZxTgU="
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-0.0.33.tgz",
+      "integrity": "sha512-zAbqAUQmXP9/ryVysJO6XkogdIdtVIYYGmV7BzhKuagaS+75QZ6muJjeSaG5M8rdE5jQ8gyhkZ23r6l4ICmxyQ=="
     },
     "@types/lodash": {
       "version": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha1-Vfkhg7BIwsZEAq/kcvgzP04xmms="
+      "integrity": "sha1-Vfkhg7BIwsZEAq/kcvgzP04xmms=",
+      "dev": true
     },
     "@types/marked": {
       "version": "https://registry.npmjs.org/@types/marked/-/marked-0.0.28.tgz",
@@ -228,16 +308,19 @@
       "dev": true
     },
     "@types/mime": {
-      "version": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha1-WnMG42fFObn2VDSZ3o3VGfrDeos="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
+      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
     },
     "@types/mime-types": {
-      "version": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
       "integrity": "sha1-nKUs2jY/aZxpRmwqbM2q2RPqenM="
     },
     "@types/minimatch": {
-      "version": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha1-toPrYL41gwTvFG9XddtMDjaWpVA=",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mockery": {
@@ -250,27 +333,31 @@
       "integrity": "sha1-AVlmwK+Akha4pGzFJ7XCEZlNNvA="
     },
     "@types/platform": {
-      "version": "https://registry.npmjs.org/@types/platform/-/platform-1.3.1.tgz",
-      "integrity": "sha1-WmZhZpPjnzEbPyxkx3zyJJ49gyU="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@types/platform/-/platform-1.3.1.tgz",
+      "integrity": "sha512-XI6JKLFNBmkADRd2FtUYtEuq5LDKTNXwUIodV3ZfTNkA+g4yo+rXXXdZL3fTE24S92BjpiEVaL3f64Fxm2JOgg=="
     },
     "@types/resolve": {
-      "version": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "requires": {
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
       }
     },
     "@types/serve-static": {
-      "version": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
-      "integrity": "sha1-HSgB+mNdJ0zZfU7AfiayG0QSdJI=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "requires": {
         "@types/express-serve-static-core": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.57.tgz",
-        "@types/mime": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz"
+        "@types/mime": "2.0.0"
       }
     },
     "@types/shell-quote": {
-      "version": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.6.0.tgz",
-      "integrity": "sha1-U3spSaLr3LDTU+RI/uRbCBAhlj8="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.6.0.tgz",
+      "integrity": "sha512-BFonQx849sYB2YOJZBUEfbWdaJcqRb6+ASvgUBtcmg2JRTjBaV2Wgn0SD0gWNIZ+rd7KPysPCjLUOUXnBDUlBg=="
     },
     "@types/shelljs": {
       "version": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.3.33.tgz",
@@ -286,23 +373,32 @@
       "dev": true
     },
     "@types/source-map": {
-      "version": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
-      "integrity": "sha1-lzRZ50TMdEXIW5f3cCdbR5sTjgg="
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==",
+      "dev": true,
+      "requires": {
+        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+      }
     },
     "@types/statuses": {
-      "version": "https://registry.npmjs.org/@types/statuses/-/statuses-1.2.28.tgz",
+      "version": "1.2.28",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-1.2.28.tgz",
       "integrity": "sha1-zF8Z0haUFtVWzcoFtZsp5F+kl+I="
     },
     "@types/ws": {
-      "version": "https://registry.npmjs.org/@types/ws/-/ws-0.0.42.tgz",
-      "integrity": "sha1-L0anxzYpYUD6S3Mv//66RFmeI0Q=",
+      "version": "0.0.42",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-0.0.42.tgz",
+      "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "requires": {
         "@types/node": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz"
       }
     },
     "@types/yargs": {
-      "version": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha1-D5x7I24teM2PS2UC3hXQcoqik4U="
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
+      "dev": true
     },
     "abab": {
       "version": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -310,15 +406,16 @@
     },
     "abbrev": {
       "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
-      "version": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
         "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-        "negotiator": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+        "negotiator": "0.6.1"
       }
     },
     "acorn": {
@@ -400,7 +497,7 @@
     },
     "anymatch": {
       "version": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "requires": {
         "micromatch": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
@@ -408,10 +505,11 @@
       }
     },
     "append-transform": {
-      "version": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
       "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
       "requires": {
-        "default-require-extensions": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz"
+        "default-require-extensions": "1.0.0"
       }
     },
     "argparse": {
@@ -432,7 +530,7 @@
     },
     "arr-flatten": {
       "version": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "array-differ": {
@@ -445,7 +543,8 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-filter": {
-      "version": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw="
     },
     "array-find-index": {
@@ -454,15 +553,18 @@
       "dev": true
     },
     "array-flatten": {
-      "version": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-map": {
-      "version": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
       "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI="
     },
     "array-reduce": {
-      "version": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
       "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys="
     },
     "array-uniq": {
@@ -489,8 +591,9 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "assertion-error": {
-      "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-      "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async": {
       "version": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
@@ -537,69 +640,81 @@
       }
     },
     "babel-generator": {
-      "version": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
       "requires": {
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
         "detect-indent": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-        "jsesc": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+        "jsesc": "1.3.0",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
         "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-        "trim-right": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+        "trim-right": "1.0.1"
       }
     },
     "babel-messages": {
-      "version": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
       "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz"
+        "babel-runtime": "6.26.0"
       }
     },
     "babel-runtime": {
-      "version": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-        "regenerator-runtime": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         }
       }
     },
     "babel-template": {
-      "version": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
       "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+        "babel-runtime": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
       }
     },
     "babel-traverse": {
-      "version": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
       "requires": {
         "babel-code-frame": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-        "babel-messages": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "globals": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
         "invariant": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -607,25 +722,28 @@
       }
     },
     "babel-types": {
-      "version": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
       "requires": {
-        "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+        "babel-runtime": "6.26.0",
         "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "to-fast-properties": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+        "to-fast-properties": "1.0.3"
       }
     },
     "babylon": {
-      "version": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM="
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base64-js": {
-      "version": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
       "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
     },
     "bcrypt-pbkdf": {
@@ -642,16 +760,17 @@
       "dev": true
     },
     "benchmark": {
-      "version": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
       "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
       "requires": {
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-        "platform": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz"
+        "platform": "1.3.4"
       }
     },
     "big.js": {
       "version": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4=",
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
       "dev": true
     },
     "binary-extensions": {
@@ -672,27 +791,30 @@
       "dev": true
     },
     "body-parser": {
-      "version": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
       "requires": {
-        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+        "bytes": "2.4.0",
         "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
         "debug": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
         "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.15",
         "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-        "raw-body": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+        "qs": "6.4.0",
+        "raw-body": "2.2.0",
         "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
         },
         "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
         }
       }
@@ -706,7 +828,7 @@
     },
     "boxen": {
       "version": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-      "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -720,7 +842,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -733,7 +855,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -784,22 +906,25 @@
       }
     },
     "buffer": {
-      "version": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
       "integrity": "sha1-pyyTb3e5a/UvX357RnGAYoVR3vs=",
       "requires": {
-        "base64-js": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-        "ieee754": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
-        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        "base64-js": "0.0.8",
+        "ieee754": "1.1.8",
+        "isarray": "1.0.0"
       },
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         }
       }
     },
     "buffer-crc32": {
-      "version": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "builtin-modules": {
@@ -808,7 +933,8 @@
       "dev": true
     },
     "bytes": {
-      "version": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
       "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
     },
     "camelcase": {
@@ -861,15 +987,16 @@
       }
     },
     "chai": {
-      "version": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
       "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
       "requires": {
-        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-        "check-error": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-        "get-func-name": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-        "pathval": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.5"
       }
     },
     "chalk": {
@@ -884,14 +1011,16 @@
       }
     },
     "charm": {
-      "version": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
       "integrity": "sha1-it02cVOm2aWBMxBSxAkJkdqZXjU=",
       "requires": {
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
       }
     },
     "check-error": {
-      "version": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "chokidar": {
@@ -912,7 +1041,7 @@
     },
     "clap": {
       "version": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
-      "integrity": "sha1-TzZ0WzIAhJJVf0ZBLWbVDLmbzlE=",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
         "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz"
@@ -1147,7 +1276,7 @@
     },
     "color-convert": {
       "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha1-wSYRB66y8pTr/+ye2eytUppgl+0=",
+      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
         "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
@@ -1189,10 +1318,11 @@
       }
     },
     "commander": {
-      "version": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
       "integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
       "requires": {
-        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        "graceful-readlink": "1.0.1"
       }
     },
     "concat-map": {
@@ -1216,7 +1346,7 @@
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1230,7 +1360,7 @@
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
@@ -1262,27 +1392,31 @@
       }
     },
     "content-disposition": {
-      "version": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "content-type-parser": {
       "version": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha1-yqvoBiPmNjiyUC/Ux/Ev9M4jUuc="
+      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "cookie": {
-      "version": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
-      "version": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
       "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU="
     },
     "core-util-is": {
@@ -1323,7 +1457,7 @@
       "dependencies": {
         "boom": {
           "version": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
           "requires": {
             "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
           }
@@ -1376,7 +1510,7 @@
         },
         "debug": {
           "version": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
@@ -1544,75 +1678,83 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decompress": {
-      "version": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/decompress/-/decompress-4.2.0.tgz",
       "integrity": "sha1-eu3YVCflqS2s/lVnSnxQXpbQH50=",
       "requires": {
-        "decompress-tar": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-        "decompress-tarbz2": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-        "decompress-targz": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-        "decompress-unzip": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+        "decompress-tar": "4.1.1",
+        "decompress-tarbz2": "4.1.1",
+        "decompress-targz": "4.1.1",
+        "decompress-unzip": "4.0.1",
         "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
         "make-dir": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
         "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "strip-dirs": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz"
+        "strip-dirs": "2.1.0"
       }
     },
     "decompress-tar": {
-      "version": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-      "integrity": "sha1-cYy9P8sWIJcW5womuE57pFkuWvE=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
+      "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "requires": {
-        "file-type": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+        "file-type": "5.2.0",
         "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-        "tar-stream": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz"
+        "tar-stream": "1.5.5"
       }
     },
     "decompress-tarbz2": {
-      "version": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
-      "integrity": "sha1-MIKluIDqQEOBY0nzeLVsUWvho5s=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-4.1.1.tgz",
+      "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "requires": {
-        "decompress-tar": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-        "file-type": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+        "decompress-tar": "4.1.1",
+        "file-type": "6.2.0",
         "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-        "seek-bzip": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-        "unbzip2-stream": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz"
+        "seek-bzip": "1.0.5",
+        "unbzip2-stream": "1.2.5"
       },
       "dependencies": {
         "file-type": {
-          "version": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
-          "integrity": "sha1-5QzXXTVv/tTjBtxPW89Sp5kDqRk="
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-6.2.0.tgz",
+          "integrity": "sha512-YPcTBDV+2Tm0VqjybVd32MHdlEGAtuxS3VAYsumFokDSMG+ROT5wawGlnHDoz7bfMcMDt9hxuXvXwoKUx2fkOg=="
         }
       }
     },
     "decompress-targz": {
-      "version": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
-      "integrity": "sha1-wJvDXE0R894J8tLaU+neI+fOHu4=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-4.1.1.tgz",
+      "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "requires": {
-        "decompress-tar": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
-        "file-type": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+        "decompress-tar": "4.1.1",
+        "file-type": "5.2.0",
         "is-stream": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
       }
     },
     "decompress-unzip": {
-      "version": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-4.0.1.tgz",
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "requires": {
-        "file-type": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
-        "get-stream": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
         "pify": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-        "yauzl": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz"
+        "yauzl": "2.9.1"
       },
       "dependencies": {
         "file-type": {
-          "version": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
           "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
         }
       }
     },
     "deep-eql": {
-      "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "requires": {
-        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz"
+        "type-detect": "4.0.5"
       }
     },
     "deep-equal": {
@@ -1629,7 +1771,8 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
-      "version": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
       "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
       "requires": {
         "strip-bom": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
@@ -1648,7 +1791,8 @@
       "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
     },
     "destroy": {
-      "version": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "detect-indent": {
@@ -1747,11 +1891,13 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
       "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
     },
     "end-of-stream": {
-      "version": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
       "requires": {
         "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
@@ -1766,11 +1912,13 @@
       }
     },
     "es6-promise": {
-      "version": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
       "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
     "escape-html": {
-      "version": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
@@ -1779,7 +1927,7 @@
     },
     "escodegen": {
       "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
-      "integrity": "sha1-mBGi8mXcHNOJRCDuNxcGS2MriFI=",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "requires": {
         "esprima": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
         "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
@@ -1801,7 +1949,8 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
-      "version": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter2": {
@@ -1844,49 +1993,52 @@
       }
     },
     "express": {
-      "version": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
+      "version": "4.15.5",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
       "integrity": "sha1-ZwI1ypWYiQpa6BcLg9tyK4Qu2Sc=",
       "requires": {
-        "accepts": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
-        "array-flatten": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-        "content-disposition": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+        "accepts": "1.3.4",
+        "array-flatten": "1.1.1",
+        "content-disposition": "0.5.2",
         "content-type": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-        "cookie": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-        "cookie-signature": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
         "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-        "finalhandler": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-        "merge-descriptors": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-        "methods": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "finalhandler": "1.0.6",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "1.1.2",
         "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
         "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-        "path-to-regexp": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-        "proxy-addr": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-        "qs": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
-        "serve-static": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "1.1.5",
+        "qs": "6.5.0",
+        "range-parser": "1.2.0",
+        "send": "0.15.6",
+        "serve-static": "1.12.6",
+        "setprototypeof": "1.0.3",
         "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
         "type-is": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-        "utils-merge": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-        "vary": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+        "utils-merge": "1.0.0",
+        "vary": "1.1.2"
       },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
         },
         "qs": {
-          "version": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha1-jQSVTTZN7z78VbWgeT4eLIsebkk="
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
+          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
         }
       }
     },
@@ -1949,10 +2101,11 @@
       }
     },
     "fd-slicer": {
-      "version": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "requires": {
-        "pend": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+        "pend": "1.2.0"
       }
     },
     "file-sync-cmp": {
@@ -1961,7 +2114,8 @@
       "dev": true
     },
     "file-type": {
-      "version": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
       "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY="
     },
     "filename-regex": {
@@ -1982,12 +2136,13 @@
       }
     },
     "finalhandler": {
-      "version": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.6.tgz",
       "integrity": "sha1-AHrqM9Gk0+QgF/YkhIrVjSEvgU8=",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "debug": "2.6.9",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
         "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
         "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
         "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -1995,8 +2150,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -2072,11 +2228,13 @@
       }
     },
     "forwarded": {
-      "version": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
-      "version": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-exists-sync": {
@@ -2108,7 +2266,7 @@
     },
     "function-bind": {
       "version": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "gaze": {
@@ -2133,7 +2291,8 @@
       "dev": true
     },
     "get-func-name": {
-      "version": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-stdin": {
@@ -2142,7 +2301,8 @@
       "dev": true
     },
     "get-stream": {
-      "version": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
       "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
       "requires": {
         "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2173,7 +2333,7 @@
     },
     "glob": {
       "version": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "requires": {
         "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
         "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2244,8 +2404,9 @@
       }
     },
     "globals": {
-      "version": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo="
+      "version": "9.18.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
     },
     "globule": {
       "version": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
@@ -2295,7 +2456,8 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graceful-readlink": {
-      "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
       "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
     },
     "grunt": {
@@ -2407,7 +2569,7 @@
     },
     "grunt-dojo2": {
       "version": "https://registry.npmjs.org/grunt-dojo2/-/grunt-dojo2-2.0.0-beta2.15.tgz",
-      "integrity": "sha1-p1v0k5aONdY5qDFYzXzN9cjmCaU=",
+      "integrity": "sha512-inDpdjlZrb6F5VTIlMDDCPxN1wtM27axEW9feHrmzh/x1CyelfzsvfkbbmqkP/XHlVrGNmHkO8BuTSDqCDn+BA==",
       "dev": true,
       "requires": {
         "codecov.io": "https://registry.npmjs.org/codecov.io/-/codecov.io-0.1.6.tgz",
@@ -2423,7 +2585,7 @@
         "grunt-ts": "https://registry.npmjs.org/grunt-ts/-/grunt-ts-5.5.1.tgz",
         "grunt-tslint": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
         "grunt-typings": "https://registry.npmjs.org/grunt-typings/-/grunt-typings-0.1.5.tgz",
-        "intern": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
+        "intern": "4.1.5",
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
         "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
         "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
@@ -2730,7 +2892,7 @@
     },
     "hawk": {
       "version": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
       "requires": {
         "boom": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
         "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
@@ -2745,7 +2907,7 @@
     },
     "hoek": {
       "version": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-      "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
+      "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
     },
     "homedir-polyfill": {
       "version": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
@@ -2762,7 +2924,7 @@
     },
     "hosted-git-info": {
       "version": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw=",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
       "dev": true
     },
     "html-comment-regex": {
@@ -2772,18 +2934,19 @@
     },
     "html-encoding-sniffer": {
       "version": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
-      "integrity": "sha1-5w2EuU2lOqN14R/jo1G+ZkLKRvg=",
+      "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
       "requires": {
         "whatwg-encoding": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz"
       }
     },
     "http-errors": {
-      "version": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
       "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
       "requires": {
         "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
         "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-        "setprototypeof": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+        "setprototypeof": "1.0.3",
         "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
       }
     },
@@ -2823,7 +2986,7 @@
     },
     "iconv-lite": {
       "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "icss-replace-symbols": {
       "version": "https://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz",
@@ -2831,11 +2994,13 @@
       "dev": true
     },
     "ieee754": {
-      "version": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
     "immediate": {
-      "version": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "import-lazy": {
@@ -2875,69 +3040,93 @@
     },
     "ini": {
       "version": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha1-7uJfVtscnsYIXgwid4CD9Zar+Sc=",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
     },
     "intern": {
-      "version": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha1-BJ81KirH/SfcZcY31ThuSb4fUtg=",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.5.tgz",
+      "integrity": "sha512-wY3xxstQ2zHpOU/ktjMcyvzmzazyjvlcipD79RqDGm+kyMdJcyI+00qfHvPlzrwhGwX+XVs2+tqwJCiSMKzYUg==",
       "requires": {
         "@dojo/core": "https://registry.npmjs.org/@dojo/core/-/core-0.3.0.tgz",
         "@dojo/has": "https://registry.npmjs.org/@dojo/has/-/has-0.1.1.tgz",
-        "@dojo/interfaces": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.0.tgz",
+        "@dojo/interfaces": "0.2.1",
         "@dojo/shim": "https://registry.npmjs.org/@dojo/shim/-/shim-0.2.3.tgz",
-        "@theintern/digdug": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
-        "@theintern/leadfoot": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.0.3.tgz",
-        "@types/benchmark": "https://registry.npmjs.org/@types/benchmark/-/benchmark-1.0.31.tgz",
-        "@types/chai": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
+        "@theintern/digdug": "2.0.4",
+        "@theintern/leadfoot": "2.0.3",
+        "@types/benchmark": "1.0.31",
+        "@types/chai": "4.0.10",
         "@types/charm": "https://registry.npmjs.org/@types/charm/-/charm-1.0.1.tgz",
-        "@types/diff": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
-        "@types/express": "https://registry.npmjs.org/@types/express/-/express-4.0.39.tgz",
-        "@types/http-errors": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.5.34.tgz",
-        "@types/istanbul-lib-coverage": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz",
-        "@types/istanbul-lib-hook": "https://registry.npmjs.org/@types/istanbul-lib-hook/-/istanbul-lib-hook-1.0.0.tgz",
-        "@types/istanbul-lib-instrument": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.0.tgz",
-        "@types/istanbul-lib-report": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.0.tgz",
-        "@types/istanbul-lib-source-maps": "https://registry.npmjs.org/@types/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.0.tgz",
-        "@types/istanbul-reports": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.0.tgz",
-        "@types/lodash": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-        "@types/mime-types": "https://registry.npmjs.org/@types/mime-types/-/mime-types-2.1.0.tgz",
-        "@types/platform": "https://registry.npmjs.org/@types/platform/-/platform-1.3.1.tgz",
-        "@types/resolve": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
-        "@types/shell-quote": "https://registry.npmjs.org/@types/shell-quote/-/shell-quote-1.6.0.tgz",
+        "@types/diff": "3.2.2",
+        "@types/express": "4.0.39",
+        "@types/http-errors": "1.5.34",
+        "@types/istanbul-lib-coverage": "1.1.0",
+        "@types/istanbul-lib-hook": "1.0.0",
+        "@types/istanbul-lib-instrument": "1.7.1",
+        "@types/istanbul-lib-report": "1.1.0",
+        "@types/istanbul-lib-source-maps": "1.2.1",
+        "@types/istanbul-reports": "1.1.0",
+        "@types/lodash": "4.14.92",
+        "@types/mime-types": "2.1.0",
+        "@types/platform": "1.3.1",
+        "@types/resolve": "0.0.4",
+        "@types/shell-quote": "1.6.0",
         "@types/source-map": "0.1.29",
-        "@types/statuses": "https://registry.npmjs.org/@types/statuses/-/statuses-1.2.28.tgz",
-        "@types/ws": "https://registry.npmjs.org/@types/ws/-/ws-0.0.42.tgz",
-        "benchmark": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-        "body-parser": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-        "chai": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
-        "charm": "https://registry.npmjs.org/charm/-/charm-1.0.2.tgz",
+        "@types/statuses": "1.2.28",
+        "@types/ws": "0.0.42",
+        "benchmark": "2.1.4",
+        "body-parser": "1.17.2",
+        "chai": "4.1.2",
+        "charm": "1.0.2",
         "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-        "express": "https://registry.npmjs.org/express/-/express-4.15.5.tgz",
+        "express": "4.15.5",
         "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+        "http-errors": "1.6.2",
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-        "istanbul-lib-hook": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-        "istanbul-lib-instrument": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.5.tgz",
+        "istanbul-lib-hook": "1.0.7",
+        "istanbul-lib-instrument": "1.7.5",
         "istanbul-lib-report": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-        "istanbul-lib-source-maps": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+        "istanbul-lib-source-maps": "1.2.2",
         "istanbul-reports": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
         "lodash": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
         "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
         "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-        "platform": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+        "platform": "1.3.4",
         "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-        "shell-quote": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+        "shell-quote": "1.6.1",
         "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
         "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
-        "tslib": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-        "ws": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz"
+        "tslib": "1.8.1",
+        "ws": "2.3.1"
       },
       "dependencies": {
+        "@dojo/interfaces": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
+          "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
+          "requires": {
+            "@types/yargs": "8.0.3"
+          }
+        },
+        "@types/lodash": {
+          "version": "4.14.92",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
+          "integrity": "sha512-cdvY1fyUGYgG7/i07a/sR5PnD6+Z+ljUrD0CNVf0qj645VvEdLNtZPjvCp4siPy3rQ/KRXMfUATIqi3+9x57Sw=="
+        },
         "@types/source-map": {
           "version": "0.1.29",
           "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.1.29.tgz",
           "integrity": "sha1-1wSKYBgLCfiqbVO9oxHGtRy9cBg="
+        },
+        "@types/yargs": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+          "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w=="
+        },
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
         }
       }
     },
@@ -2948,7 +3137,7 @@
     },
     "intersection-observer": {
       "version": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.4.3.tgz",
-      "integrity": "sha1-Iv8HRCJp2L5pRVGnguCwgezUrf0="
+      "integrity": "sha512-sRobbVo/+DVGkbco/UkuREmXSr5ypWeQ7S7tYDhzIIP3NFtAHLkkFYdivFAIgNe4sfDYBFAjxEgUyxiEmA/dgQ=="
     },
     "invariant": {
       "version": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
@@ -2963,7 +3152,8 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
     },
     "is-absolute": {
@@ -2995,7 +3185,7 @@
     },
     "is-buffer": {
       "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
@@ -3055,7 +3245,8 @@
       }
     },
     "is-natural-number": {
-      "version": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz",
       "integrity": "sha1-q5124dtM7VHjXeDHLr7PCfc0zeg="
     },
     "is-npm": {
@@ -3278,31 +3469,33 @@
     },
     "istanbul-lib-coverage": {
       "version": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
-      "integrity": "sha1-c7+5mIhSmUFck9OKPprfeEp3qdo="
+      "integrity": "sha512-0+1vDkmzxqJIn5rcoEqapSB4DmPxE31EtI2dF2aCkV5esN9EWHxZ0dwgDClivMXJqE7zaYQxq30hj5L0nlTN5Q=="
     },
     "istanbul-lib-hook": {
-      "version": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
-      "integrity": "sha1-3WYH8DB2V4/n1vKmMM8UO0m6zdw=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.0.7.tgz",
+      "integrity": "sha512-3U2HB9y1ZV9UmFlE12Fx+nPtFqIymzrqCksrXujm3NVbAZIJg/RfYgO1XiIa0mbmxTjWpVEVlkIZJ25xVIAfkQ==",
       "requires": {
-        "append-transform": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz"
+        "append-transform": "0.4.0"
       }
     },
     "istanbul-lib-instrument": {
-      "version": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.5.tgz",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.5.tgz",
       "integrity": "sha1-rbWW+PDLi5XnOSBjUaOKWGryGx4=",
       "requires": {
-        "babel-generator": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
-        "babel-template": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-        "babel-traverse": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-        "babel-types": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-        "babylon": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
+        "babel-generator": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-traverse": "6.26.0",
+        "babel-types": "6.26.0",
+        "babylon": "6.18.0",
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
         "semver": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
       }
     },
     "istanbul-lib-report": {
       "version": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz",
-      "integrity": "sha1-kivifBO5URuXm9FYc1n2l5jB1CU=",
+      "integrity": "sha512-UTv4VGx+HZivJQwAo1wnRwe1KTvFpfi/NYwN7DcsrdzMXwpRT/Yb6r4SBPoHWj4VuQPakR32g4PUUeyKkdDkBA==",
       "requires": {
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -3320,10 +3513,11 @@
       }
     },
     "istanbul-lib-source-maps": {
-      "version": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
-      "integrity": "sha1-dQV4YCQ18ooMBO5tfZ4PKWDmLBw=",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz",
+      "integrity": "sha512-8BfdqSfEdtip7/wo1RnrvLpHVEd8zMZEDmOFEnpC6dg0vXflHt9nvoAyQUzig2uMSXfF2OBEYBV3CVjIL9JvaQ==",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+        "debug": "3.1.0",
         "istanbul-lib-coverage": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz",
         "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
         "rimraf": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
@@ -3331,8 +3525,9 @@
       },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
@@ -3341,14 +3536,14 @@
     },
     "istanbul-reports": {
       "version": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.1.3.tgz",
-      "integrity": "sha1-O54eje+20YsdQl2o6LMsWhY/LRA=",
+      "integrity": "sha512-ZEelkHh8hrZNI5xDaKwPMFwDsUf5wIEI2bXAFGp1e6deR2mnEKBPhLJEgr4ZBt8Gi6Mj38E/C8kcy9XLggVO2Q==",
       "requires": {
         "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz"
       }
     },
     "js-base64": {
       "version": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
-      "integrity": "sha1-nlZv7mJHUaHXIMlmzWIm0p1AJao=",
+      "integrity": "sha512-Wehd+7Pf9tFvGb+ydPm9TjYjV8X1YHOVyG8QyELZxEMqOhemVwGRmoG8iQ/soqI3n8v4xn59zaLxiCJiaaRzKA==",
       "dev": true
     },
     "js-tokens": {
@@ -3404,7 +3599,8 @@
       }
     },
     "jsesc": {
-      "version": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
     "json-schema": {
@@ -3447,27 +3643,30 @@
       }
     },
     "jszip": {
-      "version": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-      "integrity": "sha1-48KmxtcGrG5gMxQDbUPNQL7v3zc=",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "requires": {
-        "core-js": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
-        "es6-promise": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
-        "lie": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
-        "pako": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz"
+        "core-js": "2.3.0",
+        "es6-promise": "3.0.2",
+        "lie": "3.1.1",
+        "pako": "1.0.6",
+        "readable-stream": "2.0.6"
       },
       "dependencies": {
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "requires": {
             "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "isarray": "1.0.0",
             "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
             "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -3513,10 +3712,11 @@
       }
     },
     "lie": {
-      "version": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
-        "immediate": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
+        "immediate": "3.0.6"
       }
     },
     "listify": {
@@ -3719,7 +3919,7 @@
     },
     "lru-cache": {
       "version": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
+      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
       "requires": {
         "pseudomap": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
         "yallist": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
@@ -3732,7 +3932,7 @@
     },
     "make-dir": {
       "version": "https://registry.npmjs.org/make-dir/-/make-dir-1.1.0.tgz",
-      "integrity": "sha1-GbQ2n+SMEW9Twq+VrRAsDjnoXVE=",
+      "integrity": "sha512-0Pkui4wLJ7rxvmfUvs87skoEaxmu0hCUApF8nonzpl7q//FWp9zu8W61Scz4sd/kUiqDxvUhtoam2efDyiBzcA==",
       "requires": {
         "pify": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz"
       },
@@ -3808,11 +4008,13 @@
       }
     },
     "merge-descriptors": {
-      "version": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
       "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "methods": {
-      "version": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromatch": {
@@ -3868,7 +4070,7 @@
     },
     "minimatch": {
       "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
       }
@@ -3912,7 +4114,8 @@
       "dev": true
     },
     "negotiator": {
-      "version": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nopt": {
@@ -3925,7 +4128,7 @@
     },
     "normalize-package-data": {
       "version": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -3977,7 +4180,7 @@
     },
     "nwmatcher": {
       "version": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.3.tgz",
-      "integrity": "sha1-ZDSOOz2A8DW0CsEVY9J4+LctuJw="
+      "integrity": "sha512-IKdSTiDWCarf2JTS5e9e2+5tPZGdkRJ79XjYV0pzK8Q9BpsFyBq1RGKxzs7Q8UBushGw7m6TzVKz6fcY99iSWw=="
     },
     "oauth-sign": {
       "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -4063,7 +4266,7 @@
     },
     "os-locale": {
       "version": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha1-QrwpAKa1uL0XN2yOiCtlr8zyS/I=",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
       "dev": true,
       "requires": {
         "execa": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -4159,8 +4362,9 @@
       }
     },
     "pako": {
-      "version": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
-      "integrity": "sha1-AQEhG6pwxLykoPY/Igbpe3368lg="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.6.tgz",
+      "integrity": "sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg=="
     },
     "parse-git-config": {
       "version": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-0.4.3.tgz",
@@ -4241,7 +4445,8 @@
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
-      "version": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
@@ -4255,11 +4460,13 @@
       }
     },
     "pathval": {
-      "version": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
       "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA="
     },
     "pend": {
-      "version": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "pepjs": {
@@ -4303,7 +4510,8 @@
       }
     },
     "platform": {
-      "version": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.4.tgz",
       "integrity": "sha1-bw+xftqqSPIUQrOpdcBjEw8cPr0="
     },
     "pleeease-filters": {
@@ -4364,7 +4572,7 @@
     },
     "postcss": {
       "version": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-      "integrity": "sha1-ut+hSX1GJE9jkPWLMZgw2RB4U8U=",
+      "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
       "dev": true,
       "requires": {
         "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -4692,7 +4900,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -4700,7 +4908,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -4725,7 +4933,7 @@
         },
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -4870,7 +5078,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -4878,7 +5086,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -4903,7 +5111,7 @@
         },
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -4927,7 +5135,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -4935,7 +5143,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -4960,7 +5168,7 @@
         },
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -4984,7 +5192,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -4992,7 +5200,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -5017,7 +5225,7 @@
         },
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -5041,7 +5249,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -5049,7 +5257,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -5074,7 +5282,7 @@
         },
         "source-map": {
           "version": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
         },
         "supports-color": {
@@ -5312,11 +5520,12 @@
       }
     },
     "proxy-addr": {
-      "version": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "requires": {
-        "forwarded": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-        "ipaddr.js": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz"
+        "forwarded": "0.1.2",
+        "ipaddr.js": "1.4.0"
       }
     },
     "pseudomap": {
@@ -5334,7 +5543,7 @@
     },
     "qs": {
       "version": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "query-string": {
       "version": "https://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
@@ -5347,7 +5556,7 @@
     },
     "randomatic": {
       "version": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
+      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
         "is-number": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -5383,20 +5592,23 @@
       }
     },
     "range-parser": {
-      "version": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
       "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
       "requires": {
-        "bytes": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-        "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+        "bytes": "2.4.0",
+        "iconv-lite": "0.4.15",
         "unpipe": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
       },
       "dependencies": {
         "iconv-lite": {
-          "version": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+          "version": "0.4.15",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
           "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
         }
       }
@@ -5533,16 +5745,12 @@
     },
     "regenerate": {
       "version": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha1-DDNtOYBVPXVcObWGrjsgqknIK38=",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
       "dev": true
-    },
-    "regenerator-runtime": {
-      "version": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha1-flT+W1zNXWYk6mJVw0c74JC4AuE="
     },
     "regex-cache": {
       "version": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
         "is-equal-shallow": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
@@ -5636,7 +5844,7 @@
     },
     "request": {
       "version": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-      "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+      "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
       "requires": {
         "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
         "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
@@ -5690,7 +5898,7 @@
     },
     "resolve": {
       "version": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-      "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
+      "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "requires": {
         "path-parse": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
       }
@@ -5728,14 +5936,14 @@
     },
     "rimraf": {
       "version": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
       }
     },
     "safe-buffer": {
       "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
     },
     "samsam": {
       "version": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
@@ -5743,18 +5951,19 @@
     },
     "sax": {
       "version": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "seek-bzip": {
-      "version": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
       "integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
       "requires": {
-        "commander": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz"
+        "commander": "2.8.1"
       }
     },
     "semver": {
       "version": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "semver-diff": {
       "version": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
@@ -5765,45 +5974,49 @@
       }
     },
     "send": {
-      "version": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
+      "version": "0.15.6",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.15.6.tgz",
       "integrity": "sha1-IPI6nJJbdiq4JwX+L52yUqzkfjQ=",
       "requires": {
-        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+        "debug": "2.6.9",
         "depd": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-        "destroy": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-        "etag": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-        "fresh": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-        "http-errors": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-        "mime": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+        "destroy": "1.0.4",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
+        "etag": "1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "1.6.2",
+        "mime": "1.3.4",
         "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
         "on-finished": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-        "range-parser": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+        "range-parser": "1.2.0",
         "statuses": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
       },
       "dependencies": {
         "debug": {
-          "version": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
           }
         },
         "mime": {
-          "version": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
         }
       }
     },
     "serve-static": {
-      "version": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
+      "version": "1.12.6",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.6.tgz",
       "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
       "requires": {
-        "encodeurl": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-        "escape-html": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+        "encodeurl": "1.0.1",
+        "escape-html": "1.0.3",
         "parseurl": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-        "send": "https://registry.npmjs.org/send/-/send-0.15.6.tgz"
+        "send": "0.15.6"
       }
     },
     "set-blocking": {
@@ -5817,7 +6030,8 @@
       "dev": true
     },
     "setprototypeof": {
-      "version": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "shebang-command": {
@@ -5834,12 +6048,13 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
       "requires": {
-        "array-filter": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-        "array-map": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-        "array-reduce": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+        "array-filter": "0.0.1",
+        "array-map": "0.0.0",
+        "array-reduce": "0.0.0",
         "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
       }
     },
@@ -5880,7 +6095,7 @@
     },
     "sntp": {
       "version": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
       "requires": {
         "hoek": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
       }
@@ -5978,7 +6193,7 @@
     },
     "string-width": {
       "version": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
         "is-fullwidth-code-point": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -6023,10 +6238,11 @@
       }
     },
     "strip-dirs": {
-      "version": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
-      "integrity": "sha1-SYdzYmT8NEzyD2w0rKnRPR1O1sU=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-2.1.0.tgz",
+      "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "requires": {
-        "is-natural-number": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-4.0.1.tgz"
+        "is-natural-number": "4.0.1"
       }
     },
     "strip-eof": {
@@ -6100,42 +6316,47 @@
       }
     },
     "tar-stream": {
-      "version": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-      "integrity": "sha1-XK2Ed59FyDsfJQjZawnYjHIYr1U=",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
+      "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
       "requires": {
-        "bl": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
-        "end-of-stream": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.0.tgz",
-        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+        "bl": "1.2.1",
+        "end-of-stream": "1.4.0",
+        "readable-stream": "2.3.3",
         "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
       },
       "dependencies": {
         "bl": {
-          "version": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.1.tgz",
           "integrity": "sha1-ysMo977kVzDUBLaSID/LWQ4XLV4=",
           "requires": {
-            "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+            "readable-stream": "2.3.3"
           }
         },
         "isarray": {
-          "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
-          "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "requires": {
             "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
             "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "isarray": "1.0.0",
             "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
             "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "string_decoder": "1.0.3",
             "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
           }
         },
         "string_decoder": {
-          "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "requires": {
             "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
           }
@@ -6204,7 +6425,7 @@
     },
     "throat": {
       "version": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
-      "integrity": "sha1-UMsGcO28QCN7njR9fh+I5GIK+DY=",
+      "integrity": "sha512-/EY8VpvlqJ+sFtLPeOgc8Pl7kQVOWv0woD87KTXVHPIAE842FGT+rokxIhe8xIUP1cfgrkt0as0vDLjDiMtr8w==",
       "dev": true
     },
     "through": {
@@ -6352,7 +6573,8 @@
       }
     },
     "to-fast-properties": {
-      "version": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "touch": {
@@ -6390,7 +6612,8 @@
       "dev": true
     },
     "trim-right": {
-      "version": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
     },
     "tslib": {
@@ -6438,8 +6661,9 @@
       }
     },
     "type-detect": {
-      "version": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
-      "integrity": "sha1-1w5byB223io4G8rKDG4MvcdjXeI="
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.5.tgz",
+      "integrity": "sha512-N9IvkQslUGYGC24RkJk1ba99foK6TkwC2FHAEBlQFBP0RxQZS8ZpJuAZcwiY/w9ZJHFQb1aOXBI60OdxhTrwEQ=="
     },
     "type-is": {
       "version": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
@@ -6451,7 +6675,7 @@
     },
     "typed-css-modules": {
       "version": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.1.tgz",
-      "integrity": "sha1-juHiNbZYDVPlxO+NNp5hQSdZBow=",
+      "integrity": "sha512-RHIKxvl9ytIGM1H13dFTJI44EslhMAZQobY6Do8EIy7JsZI65REQ+N5NHInyOAfvnEWmhIaMrlrDGdLFFIRGow==",
       "dev": true,
       "requires": {
         "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
@@ -6466,7 +6690,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -6484,7 +6708,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -6518,7 +6742,7 @@
         },
         "fsevents": {
           "version": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-          "integrity": "sha1-EfgjGPX+e7LNIpZaEI6TBiCCFtg=",
+          "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7599,7 +7823,7 @@
         },
         "readable-stream": {
           "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
+          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
             "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -7624,7 +7848,7 @@
         },
         "string_decoder": {
           "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
             "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
@@ -7736,7 +7960,8 @@
       "dev": true
     },
     "typescript": {
-      "version": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
       "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
     },
     "typings-core": {
@@ -7773,7 +7998,7 @@
         "thenify": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
         "throat": "https://registry.npmjs.org/throat/-/throat-3.2.0.tgz",
         "touch": "https://registry.npmjs.org/touch/-/touch-1.0.0.tgz",
-        "typescript": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+        "typescript": "2.6.2",
         "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
         "zip-object": "https://registry.npmjs.org/zip-object/-/zip-object-0.1.0.tgz"
       }
@@ -7837,8 +8062,9 @@
       "optional": true
     },
     "ultron": {
-      "version": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "umd-wrapper": {
       "version": "https://registry.npmjs.org/umd-wrapper/-/umd-wrapper-0.1.0.tgz",
@@ -7846,10 +8072,11 @@
       "dev": true
     },
     "unbzip2-stream": {
-      "version": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-      "integrity": "sha1-c6AzpWe7veWWVLGTxE1Ip+T0PEc=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
+      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
       "requires": {
-        "buffer": "https://registry.npmjs.org/buffer/-/buffer-3.6.0.tgz",
+        "buffer": "3.6.0",
         "through": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
       }
     },
@@ -7930,7 +8157,7 @@
       "dependencies": {
         "ansi-styles": {
           "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-          "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz"
@@ -7938,7 +8165,7 @@
         },
         "chalk": {
           "version": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha1-tepI78nBeT3MybR2fJORTT8tUro=",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
@@ -7948,7 +8175,7 @@
         },
         "configstore": {
           "version": "https://registry.npmjs.org/configstore/-/configstore-3.1.1.tgz",
-          "integrity": "sha1-CU7mYquD+tmRdnjeEU+q6o/NypA=",
+          "integrity": "sha512-5oNkD/L++l0O6xGXxb1EWS7SivtjfGQlRyxJsYgE0Z495/L81e2h4/d3r969hoPXuFItzNOKMtsXgYG4c7dYvw==",
           "dev": true,
           "requires": {
             "dot-prop": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -7961,7 +8188,7 @@
         },
         "dot-prop": {
           "version": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-          "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+          "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
           "dev": true,
           "requires": {
             "is-obj": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz"
@@ -7982,7 +8209,7 @@
         },
         "write-file-atomic": {
           "version": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
-          "integrity": "sha1-H/YVdcLipOjlENb6TiQ8zhg5mas=",
+          "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
           "dev": true,
           "requires": {
             "graceful-fs": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -8030,12 +8257,13 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
       "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
     },
     "uuid": {
       "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
     },
     "validate-npm-package-license": {
       "version": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
@@ -8047,7 +8275,8 @@
       }
     },
     "vary": {
-      "version": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "vendors": {
@@ -8085,7 +8314,7 @@
     },
     "webidl-conversions": {
       "version": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
-      "integrity": "sha1-qFWYCx8LazWbodXZ+zmulB+qY60="
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "websocket-driver": {
       "version": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -8098,12 +8327,12 @@
     },
     "websocket-extensions": {
       "version": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
     "whatwg-encoding": {
       "version": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-      "integrity": "sha1-V8I1vIZX6RTSTho5fTyC2u4Ka6M=",
+      "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
       "requires": {
         "iconv-lite": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
       }
@@ -8129,7 +8358,7 @@
     },
     "which": {
       "version": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
       "requires": {
         "isexe": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
       }
@@ -8200,15 +8429,17 @@
       }
     },
     "ws": {
-      "version": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
       "integrity": "sha1-a5Sz5EfLajY/eF6vlK9jWejoHIA=",
       "requires": {
-        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-        "ultron": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz"
+        "safe-buffer": "5.0.1",
+        "ultron": "1.1.1"
       },
       "dependencies": {
         "safe-buffer": {
-          "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
           "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
         }
       }
@@ -8227,7 +8458,7 @@
     },
     "xml2js": {
       "version": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
         "sax": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -8336,11 +8567,12 @@
       }
     },
     "yauzl": {
-      "version": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
       "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
       "requires": {
-        "buffer-crc32": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-        "fd-slicer": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.0.1"
       }
     },
     "zip-object": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-test-intern",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chalk": "^1.1.3",
     "codecov.io": "0.1.6",
     "cross-spawn": "^4.0.0",
-    "intern": "~4.1.0",
+    "intern": "^4.1.5",
     "mockery": "^1.7.0",
     "pkg-dir": "^1.0.0",
     "sinon": "^1.17.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chalk": "^1.1.3",
     "codecov.io": "0.1.6",
     "cross-spawn": "^4.0.0",
-    "intern": "^4.1.5",
+    "intern": "~4.1.5",
     "mockery": "^1.7.0",
     "pkg-dir": "^1.0.0",
     "sinon": "^1.17.5",

--- a/src/intern/intern-next.json
+++ b/src/intern/intern-next.json
@@ -26,20 +26,14 @@
       }
     ],
     "plugins": [
-      "@dojo/test-extras/support/loadJsdom",
-      "./_build/src/src"
-    ]
-  },
-  "browser": {
-    "plugins": [
-      "./_build/src/src.js"
+      "@dojo/test-extras/support/loadJsdom"
     ]
   },
   "suites": [
-    "./_build/tests/unit/all.js"
+    "./output/test/unit.js"
   ],
   "functionalSuites": [
-    "./_build/tests/functional/all.js"
+    "./output/test/functional.js"
   ],
   "leaveRemoteOpen": false,
   "coverage": [],

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,11 @@
 import { Command, Helper, OptionsHelper } from '@dojo/interfaces/cli';
 import { underline } from 'chalk';
 import * as path from 'path';
+import * as fs from 'fs';
 import runTests, { TestOptions } from './runTests';
 import javaCheck from './javaCheck';
 
 const pkgDir = require('pkg-dir');
-
-const CLI_BUILD_PACKAGE = '@dojo/cli-build-webpack';
 
 export interface TestArgs {
 	all: boolean;
@@ -43,6 +42,21 @@ function transformTestArgs(args: TestArgs): TestOptions {
 	let remoteUnit = false;
 	let remoteFunctional = false;
 
+	const projectRoot = pkgDir.sync(process.cwd());
+	const nextPath = path.join(projectRoot, 'output', 'test', 'unit.js');
+	const legacyPath = path.join(projectRoot, '_build', 'tests', 'unit', 'all.js');
+	const isNext = fs.existsSync(nextPath);
+	const isLegacy = fs.existsSync(legacyPath);
+	let internConfig = 'intern.json';
+
+	if (isNext) {
+		internConfig = 'intern-next.json';
+	}
+	else if (isLegacy) {}
+	else {
+		throw new Error('could not find tests, have you built the tests using dojo build?');
+	}
+
 	if (args.all) {
 		nodeUnit = remoteUnit = remoteFunctional = true;
 	}
@@ -57,8 +71,8 @@ function transformTestArgs(args: TestArgs): TestOptions {
 	}
 
 	return {
+		internConfig,
 		childConfig: args.config,
-		internConfig: args.internConfig,
 		reporters: args.reporters,
 		userName: args.userName,
 		secret: args.secret,
@@ -72,18 +86,18 @@ function transformTestArgs(args: TestArgs): TestOptions {
 	};
 }
 
-function printBrowserLink(args: TestArgs) {
+function printBrowserLink(options: TestOptions) {
 	const browserArgs = [];
 
-	if (args.filter) {
-		browserArgs.push('grep=' + encodeURIComponent(args.filter));
+	if (options.filter) {
+		browserArgs.push('grep=' + encodeURIComponent(options.filter));
 	}
 
-	console.log('\n If the project directory is hosted on a local server, unit tests can also be run in browser by navigating to ' + underline(`http://localhost:<port>/node_modules/intern/?config=node_modules/@dojo/cli-test-intern/intern/intern.json${browserArgs.length ? `&${browserArgs.join('&')}` : ''}`));
+	console.log('\n If the project directory is hosted on a local server, unit tests can also be run in browser by navigating to ' + underline(`http://localhost:<port>/node_modules/intern/?config=node_modules/@dojo/cli-test-intern/intern/${options.internConfig}${browserArgs.length ? `&${browserArgs.join('&')}` : ''}`));
 }
 
 const command: Command<TestArgs> = {
-	description: 'this command will implicitly build your application and then run tests against that build',
+	description: 'run unit and/or functional tests for your application',
 	register(options: OptionsHelper) {
 		options('a', {
 			alias: 'all',
@@ -173,35 +187,19 @@ const command: Command<TestArgs> = {
 
 		return javaCheck(args).then((javaCheckPassed) => {
 			if (javaCheckPassed) {
+				const testOptions = transformTestArgs(args);
 				return new Promise<void>((resolve, reject) => {
-					if (!helper.command.exists('build')) {
-						reject(Error(`Required command: 'build', does not exist. Have you run 'npm install ${CLI_BUILD_PACKAGE}'?`));
-					}
-					try {
-						const projectName = require(path.join(process.cwd(), './package.json')).name;
-						console.log('\n' + underline(`building "${projectName}"...`));
-					}
-					catch (e) {
-						console.log('\n' + underline(`building project...`));
-					}
-					const result = helper.command.run('build', '',
-						<any> { withTests: true, disableLazyWidgetDetection: true });
-					result.then(
-						() => {
-							runTests(transformTestArgs(args))
-								.then(() => {
-									process.removeListener('unhandledRejection', unhandledRejection);
-								})
-								.then(() => {
-									printBrowserLink(args);
-								}, (err) => {
-									printBrowserLink(args);
-									throw err;
-								})
-								.then(resolve, reject);
-						},
-						reject
-					);
+					runTests(testOptions)
+						.then(() => {
+							process.removeListener('unhandledRejection', unhandledRejection);
+						})
+						.then(() => {
+							printBrowserLink(testOptions);
+						}, (err) => {
+							printBrowserLink(testOptions);
+							throw err;
+						})
+						.then(resolve, reject);
 				});
 			} else {
 				return Promise.reject(Error(underline('Error! Java VM could not be found.') +
@@ -220,7 +218,8 @@ const command: Command<TestArgs> = {
 			copy: {
 				path: __dirname + '/intern',
 				files: [
-					'./intern.json'
+					'./intern.json',
+					'./intern-next.json'
 				]
 			}
 		};

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,7 +54,7 @@ function transformTestArgs(args: TestArgs): TestOptions {
 	}
 	else if (isLegacy) {}
 	else {
-		throw new Error('could not find tests, have you built the tests using dojo build?');
+		throw new Error('Could not find tests, have you built the tests using dojo build?\n\nFor @dojo/cli-build-app run: dojo build app --mode test\nFor @dojo/cli-build-webpack run: dojo build webpack --withTests');
 	}
 
 	if (args.all) {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -38,13 +38,8 @@ export function parseArguments(testArgs: TestOptions) {
 	} = testArgs;
 
 	const configArg = childConfig ? `@${childConfig}` : '';
-	const args = [
-		internConfig
-			? `config=${path.relative(process.cwd(), internConfig)}`
-			: `config=${path.relative(process.cwd(), path.join(packagePath, 'intern', 'intern.json' + configArg))}`
-	];
-
-	args.push(`basePath=${process.cwd()}`);
+	const configPath = path.relative(process.cwd(), path.join(packagePath, 'intern', internConfig + configArg));
+	const args = [ `config=${configPath}`];
 
 	// by default, in the intern config, all tests are run. we need to
 	// disable tests that we dont want to run

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs';
+import * as path from 'path';
 import * as mockery from 'mockery';
 import * as sinon from 'sinon';
 import MockModule from '../support/MockModule';
@@ -241,8 +242,8 @@ describe('main', () => {
 	describe('intern config switching for forward compatibility', () => {
 
 		it('should use intern.json for legacy tests built with cli-build-webpack', async () => {
-			sandbox.stub(fs, 'existsSync', (path: string) => {
-				if (path.indexOf('_build/tests/unit/all.js') !== -1) {
+			sandbox.stub(fs, 'existsSync', (testPath: string) => {
+				if (testPath.indexOf(path.join('_build', 'tests', 'unit', 'all.js')) !== -1) {
 					return true;
 				}
 				return false;
@@ -253,8 +254,8 @@ describe('main', () => {
 		});
 
 		it('should use intern-next.json for tests built with cli-build-app', async () => {
-			sandbox.stub(fs, 'existsSync', (path: string) => {
-				if (path.indexOf('output/test/unit.js') !== -1) {
+			sandbox.stub(fs, 'existsSync', (testPath: string) => {
+				if (testPath.indexOf(path.join('output', 'test', 'unit.js')) !== -1) {
 					return true;
 				}
 				return false;

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -273,7 +273,7 @@ describe('main', () => {
 			} catch (e) {
 				error = e;
 			}
-			assert.equal(error!.message, 'could not find tests, have you built the tests using dojo build?');
+			assert.equal(error!.message, 'Could not find tests, have you built the tests using dojo build?\n\nFor @dojo/cli-build-app run: dojo build app --mode test\nFor @dojo/cli-build-webpack run: dojo build webpack --withTests');
 		});
 
 	});

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -41,12 +41,13 @@ describe('runTests', () => {
 	it('Should support logging verbose information', async () => {
 		spawnOnStub.onFirstCall().callsArg(1);
 		await runTests.default({
+			internConfig: 'intern.json',
 			verbose: true
 		});
 		assert.strictEqual(consoleStub.callCount, 4);
 		assert.include(consoleStub.getCall(0).args[0], 'testing "');
 		assert.include(consoleStub.getCall(1).args[0], 'Parsed arguments for intern:');
-		assert.include(consoleStub.getCall(2).args[0], `config=${path.join('intern', 'intern')}`);
+		assert.include(consoleStub.getCall(2).args[0], `config=${path.join('intern', 'intern.json')}`);
 		assert.include(consoleStub.getCall(3).args[0], ' completed successfully');
 	});
 	it('Should call spawn to run intern', async () => {
@@ -104,14 +105,6 @@ describe('runTests', () => {
 	});
 
 	describe('Should parse arguments', () => {
-		it('Should use config to set intern file if provided', () => {
-			assert.equal(runTests.parseArguments({ childConfig: 'test' })[0], path.join('config=intern', 'intern.json@test'));
-		});
-
-		it('Should have a default for intern config', () => {
-			assert.equal(runTests.parseArguments({})[0], path.join('config=intern', 'intern.json'));
-		});
-
 		it('Should push an empty environments arg if functional tests and remote unit tests are not required', () => {
 			assert.include(runTests.parseArguments({ remoteFunctional: false }), 'environments=');
 		});
@@ -176,15 +169,6 @@ describe('runTests', () => {
 				'tunnelOptions={ "username": "user", "accessKey": "key" }');
 		});
 
-		it('Should set a specific intern config if provided', () => {
-			assert.include(
-				runTests.parseArguments({
-					internConfig: 'foo/bar'
-				}),
-				`config=${path.join('foo', 'bar')}`
-			);
-		});
-
 		it('Should add grep if filter provided', () => {
 			assert.include(runTests.parseArguments({
 				filter: 'test'
@@ -215,11 +199,6 @@ describe('runTests', () => {
 				}), capabilitiesBase + ' }',
 				'Didn\'t add default config config'
 			);
-		});
-
-		it('Should pass the basePath as the current working directory', async () => {
-			const args = runTests.parseArguments({});
-			assert.include(args, `basePath=${process.cwd()}`);
 		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds support for tests built with `cli-build-app`, as well as continuing to support `cli-build-webpack`.

Removes the ability for `cli-test-intern` to build the tests, this for now will have to be done separately.

Resolves #85 

  