### PR TITLE
Remove options that have no effect, move coverage output

### DIFF
--- a/src/intern/intern-next.json
+++ b/src/intern/intern-next.json
@@ -18,11 +18,15 @@
       {
         "name": "lcov",
         "options": {
-          "filename": "../coverage-final.lcov"
+          "directory": "output/coverage/lcov",
+          "filename": "coverage.lcov"
         }
       },
       {
-        "name": "htmlcoverage"
+        "name": "htmlcoverage",
+        "options": {
+            "directory": "output/coverage/html"
+        }
       }
     ],
     "plugins": [

--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -18,11 +18,15 @@
       {
         "name": "lcov",
         "options": {
-          "filename": "../coverage-final.lcov"
+          "directory": "output/coverage/lcov",
+          "filename": "coverage.lcov"
         }
       },
       {
-        "name": "htmlcoverage"
+        "name": "htmlcoverage",
+        "options": {
+            "directory": "output/coverage/html"
+        }
       }
     ],
     "plugins": [

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,7 +11,6 @@ export interface TestArgs {
 	all: boolean;
 	browser: boolean;
 	config?: string;
-	coverage?: boolean;
 	functional: boolean;
 	reporters?: string;
 	testingKey?: string;
@@ -78,7 +77,6 @@ function transformTestArgs(args: TestArgs): TestOptions {
 		secret: args.secret,
 		testingKey: args.testingKey,
 		verbose: args.verbose,
-		coverage: args.coverage,
 		filter: args.filter,
 		nodeUnit,
 		remoteUnit,
@@ -111,11 +109,6 @@ const command: Command<TestArgs> = {
 			type: 'string'
 		});
 
-		options('cov', {
-			alias: 'coverage',
-			describe: `If specified, additional coverage reports will be written.  The will be output to the path specified in argument '-o'/'--output'.`
-		});
-
 		options('f', {
 			alias: 'functional',
 			describe: 'Runs only functional tests. Tests are run via the local tunnel',
@@ -132,13 +125,6 @@ const command: Command<TestArgs> = {
 			alias: 'userName',
 			describe: 'User name for testing platform',
 			type: 'string'
-		});
-
-		options('o', {
-			alias: 'output',
-			describe: `The path to output any test output to (e.g. coverage information). Defaults to './output/tests'`,
-			type: 'string',
-			default: './output/tests'
 		});
 
 		options('r', {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -19,7 +19,6 @@ export interface TestOptions {
 	secret?: string;
 	testingKey?: string;
 	verbose?: boolean;
-	coverage?: boolean;
 	filter?: string;
 }
 

--- a/tests/unit/main.ts
+++ b/tests/unit/main.ts
@@ -63,12 +63,10 @@ describe('main', () => {
 		let untestedArguments: { [key: string]: string | undefined } = {
 			'a': 'all',
 			'c': 'config',
-			'cov': 'coverage',
 			'f': 'functional',
 			'n': 'node',
 			'k': 'testingKey',
 			'usr': 'userName',
-			'o': 'output',
 			'r': 'reporters',
 			's': 'secret',
 			'u': 'unit',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
The `--cov` arg has no effect since moving to intern 4 (it is always enabled). And the `--output` arg doesn't either.

Have also moved the output of coverage to the `output` directory
