### PR TITLE
calls `intern showConfig` when `--verbose` is passed

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -84,6 +84,8 @@ export function setLogger(value: (message: any, ...optionalParams: any[]) => voi
 
 export default async function (testArgs: TestOptions) {
 	const testRunPromise = new Promise((resolve, reject) => {
+		const internPath = path.resolve('node_modules/.bin/intern');
+		const internArgs = parseArguments(testArgs);
 
 		function succeed() {
 			logger('\n  ' + green('testing') + ' completed successfully');
@@ -101,11 +103,13 @@ export default async function (testArgs: TestOptions) {
 		logger('\n' + underline(`testing "${projectName()}"...`) + `\n`);
 
 		if (testArgs.verbose) {
+			logger(`${blue.bold('  Intern config:')}`);
+			logger('    ' + blue(String(cs.sync(internPath, ['showConfig', ... internArgs]).stdout)));
 			logger(`${blue.bold('  Parsed arguments for intern:')}`);
-			logger('    ' + blue(String(parseArguments(testArgs).join('\n    '))));
+			logger('    ' + blue(String(internArgs.join('\n    '))));
 		}
 
-		cs.spawn(path.resolve('node_modules/.bin/intern'), parseArguments(testArgs), { stdio: 'inherit' })
+		cs.spawn(internPath, internArgs, { stdio: 'inherit' })
 			.on('close', (exitCode: number) => {
 				if (exitCode) {
 					fail('Tests did not complete successfully');

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -44,11 +44,12 @@ describe('runTests', () => {
 			internConfig: 'intern.json',
 			verbose: true
 		});
-		assert.strictEqual(consoleStub.callCount, 4);
+		assert.strictEqual(consoleStub.callCount, 6);
 		assert.include(consoleStub.getCall(0).args[0], 'testing "');
-		assert.include(consoleStub.getCall(1).args[0], 'Parsed arguments for intern:');
-		assert.include(consoleStub.getCall(2).args[0], `config=${path.join('intern', 'intern.json')}`);
-		assert.include(consoleStub.getCall(3).args[0], ' completed successfully');
+		assert.include(consoleStub.getCall(1).args[0], 'Intern config:');
+		assert.include(consoleStub.getCall(3).args[0], 'Parsed arguments for intern:');
+		assert.include(consoleStub.getCall(4).args[0], `config=${path.join('intern', 'intern.json')}`);
+		assert.include(consoleStub.getCall(5).args[0], ' completed successfully');
 	});
 	it('Should call spawn to run intern', async () => {
 		spawnOnStub.onFirstCall().callsArg(1);


### PR DESCRIPTION
**Type:** feature

**Description:**

Improves the verbose flag by printing the intern config being used. Useful for copy/pasting and/or extending the packaged intern config.