### PR TITLE
Exclude JIT plugins/suites when running on node in local configuration

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -61,6 +61,15 @@
     },
     "local": {
       "extends": "built",
+      "node": {
+        "plugins": [
+          {
+            "script": "@dojo/cli-test-intern/plugins/jsdom",
+            "options": { "global": true }
+          }
+        ],
+        "suites": []
+      },
       "environments": [
         { "browserName": "node" },
         { "browserName": "chrome" }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Need to exclude the JIT specific plugins and suites when running in node using the local configuration.
