### PR TITLE
Override the JIT config in the built configuration so it applies to all other configs

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -29,14 +29,14 @@
       }
     ],
     "plugins": [
-      "@dojo/cli-test-intern/plugins/postcssRequire",
-      "@dojo/cli-test-intern/plugins/tsnode",
       {
         "script": "@dojo/cli-test-intern/plugins/jsdom",
         "options": {
           "global": true
         }
       },
+      "@dojo/cli-test-intern/plugins/postcssRequire",
+      "@dojo/cli-test-intern/plugins/tsnode",
       {
         "script": "@dojo/cli-test-intern/plugins/registerExtension",
         "options": {
@@ -52,15 +52,6 @@
   "defaultTimeout": 15000,
   "configs": {
     "built": {
-      "functionalSuites": [
-        "./output/test/functional.js"
-      ],
-      "suites": [
-        "./output/test/unit.js"
-      ]
-    },
-    "local": {
-      "extends": "built",
       "node": {
         "plugins": [
           {
@@ -70,6 +61,15 @@
         ],
         "suites": []
       },
+      "functionalSuites": [
+        "./output/test/functional.js"
+      ],
+      "suites": [
+        "./output/test/unit.js"
+      ]
+    },
+    "local": {
+      "extends": "built",
       "environments": [
         { "browserName": "node" },
         { "browserName": "chrome" }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Move the overriding node plugins and suites from `local` to `built` so that all the other configurations inherit correctly.