### PR TITLE
pin @types/node version to ~9.6.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/cli-test-intern",
-  "version": "0.5.2",
+  "version": "0.5.3-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -280,7 +280,7 @@
       "integrity": "sha512-BdN2PXxOFnTXFcyONPW6t0fHjz2fvRZHVMFpaS0wYr+Y8fWEaNOs4V8LEu/fpzQlMx+ahdndgTaGTwPC+J/EeA==",
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/chai": {
@@ -299,7 +299,7 @@
       "resolved": "https://registry.npmjs.org/@types/charm/-/charm-1.0.1.tgz",
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/diff": {
@@ -328,7 +328,7 @@
       "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/fs-extra": {
@@ -337,7 +337,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/glob": {
@@ -348,7 +348,7 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/grunt": {
@@ -357,7 +357,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/handlebars": {
@@ -429,7 +429,7 @@
       "integrity": "sha512-lthMj4kw7Fzs3LjBhQ0+1faAfDrN9GFJZO5Nf/xO7fppFfxqnnQdNR28n0xMGXsx8fTHOPliE1NTkAW1bVLpYw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.0",
+        "@types/node": "9.6.8",
         "@types/tough-cookie": "2.3.2",
         "parse5": "3.0.3"
       },
@@ -440,7 +440,7 @@
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "dev": true,
           "requires": {
-            "@types/node": "9.6.0"
+            "@types/node": "9.6.8"
           }
         }
       }
@@ -484,9 +484,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.0.tgz",
-      "integrity": "sha512-h3YZbOq2+ZoDFI1z8Zx0Ck/xRWkOESVaLdgLdd/c25mMQ1Y2CAkILu9ny5A15S5f32gGcQdaUIZ2jzYr8D7IFg=="
+      "version": "9.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.8.tgz",
+      "integrity": "sha512-0PmgMBskTJa7zDyENW9C7Lunk+I0L2CHYF2RrBRljCmLSMM1fBHIIdvE1IboNNz7N6t+raJIj90YMvUYl2VT1g=="
     },
     "@types/platform": {
       "version": "1.3.1",
@@ -498,7 +498,7 @@
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/serve-static": {
@@ -521,7 +521,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/sinon": {
@@ -570,7 +570,7 @@
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-0.0.42.tgz",
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "requires": {
-        "@types/node": "9.6.0"
+        "@types/node": "9.6.8"
       }
     },
     "@types/yargs": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/grunt": "^0.4.21",
     "@types/jsdom": "11.0.4",
     "@types/mockery": "^1.4.29",
+    "@types/node": "~9.6.5",
     "@types/sinon": "^1.16.35",
     "@types/source-map": "^0.5.0",
     "@types/yargs": "^8.0.2",


### PR DESCRIPTION
This is tracked in dojo/meta#247.