### PR TITLE
Upgrade Intern and dojo/scripts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,22 +84,13 @@
         }
       }
     },
-    "@dojo/core": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/core/-/core-2.0.0.tgz",
-      "integrity": "sha512-iojqMIn49L/bwv/Ryy2v7qKeioHxjHQqJNLhEXBJ+zJoQ47IeG92Y5tmdGsZ6SKZk6sFuWHl7gL9Wbw0qVySHw==",
-      "requires": {
-        "tslib": "~1.8.1"
-      }
-    },
     "@dojo/framework": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-3.0.1.tgz",
-      "integrity": "sha512-Yta6DPRjIH+JebCY6t7yR7PaxnGOaGKkhmpSj7R9UIzb+H33OX5pQMSacCnPkVAD+/bNvdVm0A1238QVI9RiRQ==",
+      "version": "4.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-4.0.0-alpha.2.tgz",
+      "integrity": "sha512-NahGC765Xh7SV9MjEwX/6a/GWb8Y1pO3PhZ+CyUDhWc9fuxQ+bNMNOM0Thqm0XcvelYrJHLgg/enwzE+gu8HhA==",
       "requires": {
         "@types/cldrjs": "0.4.20",
         "@types/globalize": "0.0.34",
-        "@types/web-animations-js": "2.2.5",
         "@webcomponents/webcomponentsjs": "1.1.0",
         "cldrjs": "0.4.8",
         "css-select-umd": "1.3.0-rc0",
@@ -111,19 +102,6 @@
         "web-animations-js": "2.3.1"
       }
     },
-    "@dojo/has": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/has/-/has-2.0.0.tgz",
-      "integrity": "sha512-WFdsD2jVqsLvOTtEs8Q9TlJF7f0VgO8NXRccuOPKjw9tXKvB6XrnZjGgh+zkLxOUrm8m3rExMu8MHGM8ZHLPPQ=="
-    },
-    "@dojo/interfaces": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@dojo/interfaces/-/interfaces-0.2.1.tgz",
-      "integrity": "sha512-/bIJJb9q02MxSlfA9G3n6AMTlD80fDx7qDRss/8HxeJ26ix/F/tCnX521c3XrWm/HOBEWp7GiRX5E0hQdIuCNw==",
-      "requires": {
-        "@types/yargs": "^8.0.2"
-      }
-    },
     "@dojo/loader": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@dojo/loader/-/loader-2.0.0.tgz",
@@ -131,13 +109,13 @@
       "dev": true
     },
     "@dojo/scripts": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-3.0.2.tgz",
-      "integrity": "sha512-HHGSo1IQKfiU98QyNuH4zpX3q25TuxCoCfkq0nzhlDTdEeCkOn0bEKt07E11wTG/UYJpTEfGzJr4QJ+mCUcZ0Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@dojo/scripts/-/scripts-3.1.0.tgz",
+      "integrity": "sha512-LRUeGVam7IizhvgcRU6zu4bmBXeFzuKcgeleAUHZP1NPa+DROPdidBWIdVeKL5jVHqCnTfYgAqqorsgkftOj2g==",
       "dev": true,
       "requires": {
         "chalk": "~2.4.0",
-        "intern": "~4.2.0",
+        "intern": "~4.3.0",
         "parse-git-config": "~2.0.2",
         "prettier": "1.13.7",
         "rxjs": "^5.5.6",
@@ -178,17 +156,6 @@
         }
       }
     },
-    "@dojo/shim": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/shim/-/shim-2.0.0.tgz",
-      "integrity": "sha512-v/zD80U+8ajNrfxwKH6yy//l6ATQ/LzeYVXcqmBkGQ0NA4vDujLS3ceF3Wt0XL55JXLUYaVSQACMqy0H9DPD3A==",
-      "requires": {
-        "intersection-observer": "0.4.2",
-        "pepjs": "0.4.2",
-        "tslib": "~1.8.0",
-        "web-animations-js": "2.3.1"
-      }
-    },
     "@sinonjs/formatio": {
       "version": "2.0.0",
       "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
@@ -207,19 +174,32 @@
         "array-from": "^2.1.1"
       }
     },
-    "@theintern/digdug": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.1.2.tgz",
-      "integrity": "sha512-r1QjsLCeBk6UiK2nA6g3P+nc5V/drSU6w8zmvEWIsCl397xog1h6yEovu8V9KVjISL2LbyyOLEGGnNDSlEpcVQ==",
+    "@theintern/common": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@theintern/common/-/common-0.1.1.tgz",
+      "integrity": "sha512-w9HRNyv7DZc8DeGOCafHE9WTmwsWFlEjt2Kpq3XuaPkseihiDYB4I7nghnnqpBc7ZBlnGVKyQO0tWvgK63Qq4g==",
       "requires": {
-        "@dojo/core": "~2.0.0",
-        "@dojo/has": "~2.0.0",
-        "@dojo/interfaces": "~0.2.0",
-        "@dojo/shim": "~2.0.0",
+        "axios": "~0.18.0",
+        "tslib": "~1.9.3"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+        }
+      }
+    },
+    "@theintern/digdug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.0.tgz",
+      "integrity": "sha512-whXbywglF5lnQRCURKNoFeVWTdDDQdPkRKIh4L0rboz3mrw0+vDM02WRM90rVbpITwbb+ynNBJC3d/XEo1BcPA==",
+      "requires": {
+        "@theintern/common": "~0.1.0",
         "command-exists": "~1.2.6",
         "decompress": "~4.2.0",
         "semver": "~5.5.0",
-        "tslib": "~1.9.0"
+        "tslib": "~1.9.3"
       },
       "dependencies": {
         "tslib": {
@@ -230,17 +210,13 @@
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.1.1.tgz",
-      "integrity": "sha512-g1XqAUIedSRUWTG8ElhcsXBwFtMk00VmHYYqzfRbBdM5JXcqv2uzDP04Td4sT7eGQWVrHW2pC38Zk8Hb810jsw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.0.tgz",
+      "integrity": "sha512-GbNyc+UWLhzfHVJRqH3mRORg+u86BMzI8TyeIETj9kx9N1xu8FlhiGs6t1cQ83zzmPcCDF2yoY99Wjq/7q31og==",
       "requires": {
-        "@dojo/core": "~2.0.0",
-        "@dojo/has": "~2.0.0",
-        "@dojo/interfaces": "~0.2.1",
-        "@dojo/shim": "~2.0.0",
-        "@types/jszip": "~3.1.3",
-        "jszip": "~3.1.3",
-        "tslib": "~1.9.0"
+        "@theintern/common": "~0.1.0",
+        "jszip": "~3.1.5",
+        "tslib": "~1.9.3"
       },
       "dependencies": {
         "tslib": {
@@ -270,16 +246,16 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
     "@types/chai": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.4.tgz",
-      "integrity": "sha512-h6+VEw2Vr3ORiFCyyJmcho2zALnUq9cvdB/IO8Xs9itrJVCenC7o26A6+m7D0ihTTr65eS259H5/Ghl/VjYs6g=="
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.5.tgz",
+      "integrity": "sha512-nyzJ08qQMY4umgXD6SzbLflQucEnoAf2H5iUxPX5t0euDgXDV+bFTJlEmEepM35/2l07jYHdAfP6YEndeTWM0w=="
     },
     "@types/charm": {
       "version": "1.0.1",
@@ -290,9 +266,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
@@ -310,9 +286,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
@@ -347,9 +323,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
@@ -434,21 +410,6 @@
         }
       }
     },
-    "@types/jszip": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.1.4.tgz",
-      "integrity": "sha512-UaVbz4buRlBEolZYrxqkrGDOypugYlbqGNrUFB4qBaexrLypTH0jyvaF5jolNy5D+5C4kKV1WJ3Yx9cn/JH8oA==",
-      "requires": {
-        "@types/node": "*"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
-        }
-      }
-    },
     "@types/lodash": {
       "version": "4.14.116",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.116.tgz",
@@ -495,9 +456,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
@@ -542,11 +503,6 @@
       "integrity": "sha512-MDQLxNFRLasqS4UlkWMSACMKeSm1x4Q3TxzUC7KQUsh6RK1ZrQ0VEyE3yzXcBu+K8ejVj4wuX32eUG02yNp+YQ==",
       "dev": true
     },
-    "@types/web-animations-js": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@types/web-animations-js/-/web-animations-js-2.2.5.tgz",
-      "integrity": "sha512-3kjO6yvLt1e673wtcKEz0lgLKqPkBiuwxQj0DQ1jj+48HB03emIlTQYcqKAvB9UwOXq09QrWy/Dm6ZU8xMZVTw=="
-    },
     "@types/ws": {
       "version": "4.0.2",
       "resolved": "http://registry.npmjs.org/@types/ws/-/ws-4.0.2.tgz",
@@ -557,16 +513,17 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.9.4",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.9.4.tgz",
-          "integrity": "sha512-fCHV45gS+m3hH17zgkgADUSi2RR1Vht6wOZ0jyHP8rjiQra9f+mIcgwPQHllmDocYOstIEbKlxbFDYlgrTPYqw=="
+          "version": "10.10.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.10.1.tgz",
+          "integrity": "sha512-nzsx28VwfaIykfzMAG9TB3jxF5Nn+1/WMKnmVZc8TsB+LMIVvwUscVn7PAq+LFaY5ng5u4jp5mRROSswo76PPA=="
         }
       }
     },
     "@types/yargs": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
-      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w=="
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
+      "dev": true
     },
     "@webcomponents/webcomponentsjs": {
       "version": "1.1.0",
@@ -593,12 +550,25 @@
       "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
     },
     "acorn-globals": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.1.0.tgz",
-      "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
+      "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
       "requires": {
-        "acorn": "^5.0.0"
+        "acorn": "^6.0.1",
+        "acorn-walk": "^6.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.1.tgz",
+          "integrity": "sha512-SiwgrRuRD2D1R6qjwwoopKcCTkmmIWjy1M15Wv+Nk/7VUsBad4P8GOPft2t6coDZG0TuR5dq9o1v0g8wo7F6+A=="
+        }
       }
+    },
+    "acorn-walk": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.0.1.tgz",
+      "integrity": "sha512-PqVQ8c6a3kyqdsUZlC7nljp3FFuxipBRHKu+7C1h8QygBFlzTaDX5HD383jej3Peed+1aDG8HwkfB1Z1HMNPkw=="
     },
     "ajv": {
       "version": "5.5.2",
@@ -825,6 +795,15 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1056,9 +1035,9 @@
       "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "binary-extensions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
-      "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
+      "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
       "dev": true
     },
     "bl": {
@@ -1293,9 +1272,9 @@
       }
     },
     "ci-info": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.5.1.tgz",
-      "integrity": "sha512-fKFIKXaYiL1exImwJ0AhR/6jxFPSKQBk2ayV5NiNoruUs2+rxC2kNw0EG+1Z9dugZRdCrppskQ8DN2cyaUM1Hw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
+      "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
       "dev": true
     },
     "class-utils": {
@@ -1472,9 +1451,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2494,6 +2473,24 @@
       "integrity": "sha512-Nlic4ZRYxikqnK5rj3YoxDVKGGtUjcNDUtvQ7XsdGLZmMwdUYnXf10o1zcXtzEZTBgc6GxeRpQxV/Wu3WPIIHA==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+      "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2522,6 +2519,16 @@
         "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
         "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.6",
+          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
       }
     },
     "forwarded": {
@@ -3335,6 +3342,12 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3578,29 +3591,26 @@
       }
     },
     "intern": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.2.4.tgz",
-      "integrity": "sha512-dpabLKhoBJaQdgHDkt4oEWb+yeeq8YnFcavuC8KbFaUaeZjhswMZ1vly1fSxiAh7fOKDXWj5e8sop2NGgu7PzA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.3.0.tgz",
+      "integrity": "sha512-Aso3T2y7S3y4QkJlUE1PqQc2ym2iEqbIK7V99wguDH2yYDzNxVXfbv8mdHRpPGoryb/OGVA5Oe/FoUBrfdEEyg==",
       "requires": {
-        "@dojo/core": "~2.0.0",
-        "@dojo/has": "~2.0.0",
-        "@dojo/interfaces": "~0.2.1",
-        "@dojo/shim": "~2.0.0",
-        "@theintern/digdug": "~2.1.2",
-        "@theintern/leadfoot": "~2.1.1",
+        "@theintern/common": "~0.1.0",
+        "@theintern/digdug": "~2.2.0",
+        "@theintern/leadfoot": "~2.2.0",
         "@types/benchmark": "~1.0.30",
-        "@types/chai": "~4.1.2",
+        "@types/chai": "~4.1.4",
         "@types/charm": "~1.0.0",
         "@types/diff": "~3.5.1",
         "@types/express": "~4.11.1",
         "@types/http-errors": "~1.6.1",
         "@types/istanbul-lib-coverage": "~1.1.0",
         "@types/istanbul-lib-hook": "~1.0.0",
-        "@types/istanbul-lib-instrument": "~1.7.1",
+        "@types/istanbul-lib-instrument": "~1.7.2",
         "@types/istanbul-lib-report": "~1.1.0",
         "@types/istanbul-lib-source-maps": "~1.2.1",
         "@types/istanbul-reports": "~1.1.0",
-        "@types/lodash": "~4.14.107",
+        "@types/lodash": "~4.14.112",
         "@types/mime-types": "~2.1.0",
         "@types/platform": "~1.3.0",
         "@types/resolve": "0.0.7",
@@ -3608,7 +3618,7 @@
         "@types/statuses": "~1.3.0",
         "@types/ws": "~4.0.2",
         "benchmark": "~2.1.4",
-        "body-parser": "~1.18.2",
+        "body-parser": "~1.18.3",
         "chai": "~4.1.2",
         "charm": "~1.0.2",
         "diff": "~3.5.0",
@@ -3621,15 +3631,15 @@
         "istanbul-lib-report": "~1.1.5",
         "istanbul-lib-source-maps": "~1.2.6",
         "istanbul-reports": "~1.5.1",
-        "lodash": "~4.17.5",
-        "mime-types": "~2.1.18",
+        "lodash": "~4.17.10",
+        "mime-types": "~2.1.19",
         "minimatch": "~3.0.4",
         "platform": "~1.3.5",
         "resolve": "~1.7.1",
         "shell-quote": "~1.6.1",
         "source-map": "~0.6.1",
         "statuses": "~1.5.0",
-        "tslib": "~1.9.0",
+        "tslib": "~1.9.3",
         "ws": "~5.1.1"
       },
       "dependencies": {
@@ -3696,12 +3706,11 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
@@ -3943,10 +3952,13 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
-      "dev": true
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -4757,9 +4769,9 @@
       }
     },
     "lolex": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
-      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
     "loose-envify": {
@@ -5912,7 +5924,7 @@
       "dependencies": {
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
@@ -7454,9 +7466,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.2.5.tgz",
-      "integrity": "sha512-izD3jxT8xkzwtXRUZjtmRwKnZoeECrfZ8ra/ketwOcusbZEp4mjULMnJOCfTDZBgGQAAY1AJ/IgxcwkavcX9Og==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.0.tgz",
+      "integrity": "sha512-kE2WkurNnPUMcryNioS68DDbhoPB8Qxsd8btHSj+sd5Pjh2GsjmeHLzMSqV9HHziAo8FzVxVCJl9ZYhk7yY1pA==",
       "requires": {
         "buffer": "^3.0.1",
         "through": "^2.3.6"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "devDependencies": {
     "@dojo/cli": "~3.0.0",
     "@dojo/loader": "^2.0.0",
-    "@dojo/scripts": "~3.0.1",
+    "@dojo/scripts": "~3.1.0",
     "@types/jsdom": "11.0.4",
     "@types/mockery": "^1.4.29",
     "@types/node": "~9.6.5",
@@ -56,11 +56,11 @@
     "yargs": "^5.0.0"
   },
   "dependencies": {
-    "@dojo/framework": "~3.0.0",
+    "@dojo/framework": "next",
     "chalk": "2.4.1",
     "cross-spawn": "4.0.2",
     "css-modules-require-hook": "4.2.3",
-    "intern": "~4.2.0",
+    "intern": "~4.3.0",
     "jsdom": "11.6.2",
     "pkg-dir": "1.0.0",
     "ts-node": "4.1.0",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Upgrades the intern and dojo/scripts dependencies (and framework to `next`).
