### PR TITLE
Externals support

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -48,7 +48,7 @@
       "./tests/unit/all.ts"
     ]
   },
-  "coverage": [],
+  "coverage": false,
   "defaultTimeout": 15000,
   "configs": {
     "built": {

--- a/src/loaders/externals.ts
+++ b/src/loaders/externals.ts
@@ -1,0 +1,80 @@
+declare const define: any;
+
+intern.registerLoader(async function(options = {}) {
+	const { outputPath = 'externals', dependencies = [], config } = options;
+	const externalsPath = config ? `output/test/${outputPath}/` : '';
+	// const extensions = ['.js'];
+
+	function prefixPath(path: string) {
+		return `${externalsPath}${path}`;
+	}
+
+	const paths = dependencies.reduce(
+		(
+			paths: string[],
+			dependency:
+				| string
+				| {
+						inject?: string | boolean | string[];
+						to?: string;
+						from?: string;
+				  }
+		) => {
+			if (typeof dependency === 'string') {
+				return paths;
+			}
+
+			const { inject, to, from } = dependency;
+
+			if (!inject || !from) {
+				return paths;
+			}
+
+			const base = (config && to) || from;
+			const baseDir = base[base.length - 1] === '/' ? base : `${base}/`;
+
+			if (Array.isArray(inject)) {
+				return paths.concat(inject.map((path) => prefixPath(`${baseDir}${path}`)));
+			}
+
+			return paths.concat(prefixPath(typeof inject === 'string' ? `${baseDir}${inject}` : base));
+		},
+		[]
+	);
+
+	console.log(`Paths: ${JSON.stringify(paths)}`);
+	await intern.loadScript(paths);
+
+	const globalObj: any = typeof window !== 'undefined' ? window : global;
+	const require: any = globalObj.require;
+
+	if (config && globalObj.define && globalObj.define.amd) {
+		return (modules: string[]) => {
+			let handle: { remove(): void };
+
+			return new Promise((resolve, reject) => {
+				handle = require.on('error', (error: Error) => {
+					intern.emit('error', error);
+					reject(new Error(`Dojo loader error: ${error.message}`));
+				});
+
+				intern.log('Loading modules:', modules);
+				require(modules, () => {
+					resolve();
+				});
+			}).then<void>(
+				() => {
+					handle.remove();
+				},
+				(error) => {
+					handle && handle.remove();
+					throw error;
+				}
+			);
+		};
+	}
+
+	return (modules: string[]) => {
+		return intern.loadScript(modules);
+	};
+});

--- a/src/loaders/externals.ts
+++ b/src/loaders/externals.ts
@@ -50,6 +50,13 @@ intern.registerLoader(async function(options = {}) {
 
 	if (config && globalObj.define && globalObj.define.amd) {
 		return (modules: string[]) => {
+			const paths = modules.map((module) => {
+				if (module[0] !== '/') {
+					return `${intern.config.basePath}${module}`;
+				} else {
+					return module;
+				}
+			});
 			let handle: { remove(): void };
 
 			return new Promise((resolve, reject) => {
@@ -58,8 +65,8 @@ intern.registerLoader(async function(options = {}) {
 					reject(new Error(`Dojo loader error: ${error.message}`));
 				});
 
-				intern.log('Loading modules:', modules);
-				require(modules, () => {
+				intern.log('Loading modules:', paths);
+				require(paths, () => {
 					resolve();
 				});
 			}).then<void>(

--- a/src/loaders/externals.ts
+++ b/src/loaders/externals.ts
@@ -1,9 +1,8 @@
 declare const define: any;
 
 intern.registerLoader(async function(options = {}) {
-	const { outputPath = 'externals', dependencies = [], config } = options;
-	const externalsPath = config ? `output/test/unit/${outputPath}/` : '';
-	// const extensions = ['.js'];
+	const { outputPath = 'externals', dependencies = [] } = options;
+	const externalsPath = `output/test/unit/${outputPath}/`;
 
 	function prefixPath(path: string) {
 		return `${externalsPath}${path}`;
@@ -30,7 +29,7 @@ intern.registerLoader(async function(options = {}) {
 				return paths;
 			}
 
-			const base = (config && to) || from;
+			const base = to || from;
 			const baseDir = base[base.length - 1] === '/' ? base : `${base}/`;
 
 			if (Array.isArray(inject)) {
@@ -42,13 +41,13 @@ intern.registerLoader(async function(options = {}) {
 		[]
 	);
 
-	console.log(`Paths: ${JSON.stringify(paths)}`);
 	await intern.loadScript(paths);
 
 	const globalObj: any = typeof window !== 'undefined' ? window : global;
-	const require: any = globalObj.require;
 
-	if (config && globalObj.define && globalObj.define.amd) {
+	if (globalObj.define && globalObj.define.amd) {
+		const require: any = globalObj.require;
+
 		return (modules: string[]) => {
 			const paths = modules.map((module) => {
 				if (module[0] !== '/') {

--- a/src/loaders/externals.ts
+++ b/src/loaders/externals.ts
@@ -2,7 +2,7 @@ declare const define: any;
 
 intern.registerLoader(async function(options = {}) {
 	const { outputPath = 'externals', dependencies = [], config } = options;
-	const externalsPath = config ? `output/test/${outputPath}/` : '';
+	const externalsPath = config ? `output/test/unit/${outputPath}/` : '';
 	// const extensions = ['.js'];
 
 	function prefixPath(path: string) {
@@ -62,7 +62,7 @@ intern.registerLoader(async function(options = {}) {
 			return new Promise((resolve, reject) => {
 				handle = require.on('error', (error: Error) => {
 					intern.emit('error', error);
-					reject(new Error(`Dojo loader error: ${error.message}`));
+					reject(new Error(`AMD loader error: ${error.message}`));
 				});
 
 				intern.log('Loading modules:', paths);

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,19 @@ export interface TestArgs {
 	browser: boolean;
 	config?: string;
 	functional: boolean;
+	externals?: {
+		outputPath?: string;
+		dependencies?: Array<
+			| string
+			| {
+					type?: string;
+					from: string;
+					to?: string;
+					name?: string;
+					inject?: boolean | string | string[];
+			  }
+		>;
+	};
 	reporters?: string;
 	testingKey?: string;
 	secret?: string;
@@ -87,6 +100,7 @@ function transformTestArgs(args: TestArgs): TestOptions {
 		testingKey: args.testingKey,
 		verbose: args.verbose,
 		filter: args.filter,
+		externals: args.externals,
 		nodeUnit,
 		remoteUnit,
 		remoteFunctional

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -15,6 +15,20 @@ export interface TestOptions {
 	childConfig?: string;
 	internConfig?: string;
 	reporters?: string;
+	externals?: {
+		outputPath?: string;
+		dependencies?: Array<
+			| string
+			| {
+					type?: string;
+					from: string;
+					to?: string;
+					name?: string;
+					inject?: boolean | string | string[];
+			  }
+		>;
+	};
+	loaderPlugins?: string[];
 	userName?: string;
 	secret?: string;
 	testingKey?: string;
@@ -29,6 +43,7 @@ export function parseArguments(testArgs: TestOptions) {
 		remoteFunctional,
 		childConfig,
 		internConfig,
+		externals,
 		reporters,
 		testingKey,
 		userName,
@@ -43,6 +58,18 @@ export function parseArguments(testArgs: TestOptions) {
 	// disable tests that we dont want to run
 	if (!remoteUnit && !nodeUnit) {
 		args.push('suites=');
+	}
+
+	if (externals) {
+		args.push(
+			`loader=${JSON.stringify({
+				script: '@dojo/cli-test-intern/loaders/externals',
+				options: {
+					...externals,
+					config: childConfig
+				}
+			})}`
+		);
 	}
 
 	if (!remoteUnit && !remoteFunctional) {

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -70,10 +70,7 @@ export function parseArguments(testArgs: TestOptions) {
 		args.push(
 			`loader=${JSON.stringify({
 				script: 'node_modules/@dojo/cli-test-intern/loaders/externals.js',
-				options: {
-					...externals,
-					config: childConfig
-				}
+				options: externals
 			})}`
 		);
 	}

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -61,6 +61,12 @@ export function parseArguments(testArgs: TestOptions) {
 	}
 
 	if (externals) {
+		if (!childConfig) {
+			throw new Error(
+				'Dojo JIT does not currently support externals, ' +
+					'please specify a config option to run tests against the built code'
+			);
+		}
 		args.push(
 			`loader=${JSON.stringify({
 				script: 'node_modules/@dojo/cli-test-intern/loaders/externals.js',

--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -63,7 +63,7 @@ export function parseArguments(testArgs: TestOptions) {
 	if (externals) {
 		args.push(
 			`loader=${JSON.stringify({
-				script: '@dojo/cli-test-intern/loaders/externals',
+				script: 'node_modules/@dojo/cli-test-intern/loaders/externals.js',
 				options: {
 					...externals,
 					config: childConfig

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -2,3 +2,4 @@ import './main';
 import './runTests';
 import './javaCheck';
 import './plugins/all';
+import './loaders/all';

--- a/tests/unit/loaders/all.ts
+++ b/tests/unit/loaders/all.ts
@@ -1,0 +1,4 @@
+if (intern.environment === 'node') {
+	// These node.js specific tests have node-only dependencies (i.e. mockery)
+	require('./externals');
+}

--- a/tests/unit/loaders/externals.ts
+++ b/tests/unit/loaders/externals.ts
@@ -1,0 +1,187 @@
+import { SinonSandbox, SinonStub, sandbox } from 'sinon';
+import MockModule from '../../support/MockModule';
+
+const { beforeEach, afterEach, describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
+describe('loaders/externals', () => {
+	let mockModule: MockModule;
+	let registerLoaderStub: SinonStub;
+	let loadScriptStub: SinonStub;
+	let sinon: SinonSandbox;
+
+	function assertRegisterLoader() {
+		assert.strictEqual(registerLoaderStub.callCount, 1);
+		const callback = registerLoaderStub.lastCall.args[0];
+		assert.isFunction(callback);
+
+		return callback;
+	}
+
+	beforeEach((test) => {
+		sinon = sandbox.create();
+		mockModule = new MockModule('../../../src/loaders/externals', require);
+		registerLoaderStub = sinon.stub(intern, 'registerLoader');
+		loadScriptStub = sinon.stub(intern, 'loadScript').callsFake(() => Promise.resolve());
+
+		mockModule.getModuleUnderTest();
+	});
+
+	afterEach(() => {
+		sinon.restore();
+		mockModule.destroy();
+		delete (global as any).define;
+		delete (window as any).define;
+	});
+
+	it('loader loads without options', () => {
+		const callback = assertRegisterLoader();
+		callback();
+
+		assert.isTrue(loadScriptStub.calledOnce);
+	});
+
+	it('loader parses paths to load from dependencies', () => {
+		const outputPath = 'outputPath';
+		const dependencies = [
+			'foo',
+			{ inject: true },
+			{ inject: false, from: 'foo' },
+			{ inject: true, from: 'bar.js' },
+			{ inject: 'buzz', from: 'bar', to: 'baz/' },
+			{ inject: ['foo', 'bar', 'baz'], from: 'foobarbaz' }
+		];
+		const callback = assertRegisterLoader();
+		callback({ outputPath, dependencies });
+
+		assert.isTrue(loadScriptStub.calledOnce);
+		assert.deepEqual(
+			loadScriptStub.lastCall.args,
+			[
+				[
+					'output/test/unit/outputPath/bar.js',
+					'output/test/unit/outputPath/baz/buzz',
+					'output/test/unit/outputPath/foobarbaz/foo',
+					'output/test/unit/outputPath/foobarbaz/bar',
+					'output/test/unit/outputPath/foobarbaz/baz'
+				]
+			],
+			'Did not parse correct paths'
+		);
+
+		callback({ dependencies });
+		assert.isTrue(loadScriptStub.calledTwice);
+		assert.deepEqual(
+			loadScriptStub.lastCall.args,
+			[
+				[
+					'output/test/unit/externals/bar.js',
+					'output/test/unit/externals/baz/buzz',
+					'output/test/unit/externals/foobarbaz/foo',
+					'output/test/unit/externals/foobarbaz/bar',
+					'output/test/unit/externals/foobarbaz/baz'
+				]
+			],
+			'Did not use correct default path'
+		);
+	});
+
+	it('should default to loading scripts', async () => {
+		const callback = assertRegisterLoader();
+		const load = await callback();
+
+		assert.isTrue(loadScriptStub.calledOnce);
+
+		load(['foo', 'bar', 'baz']);
+
+		assert.isTrue(loadScriptStub.calledTwice);
+		assert.deepEqual(loadScriptStub.lastCall.args, [['foo', 'bar', 'baz']]);
+	});
+
+	it('should leverage a global AMD require', async () => {
+		const callback = assertRegisterLoader();
+		const removeStub = sinon.stub();
+		const requireStub = sinon.stub().callsFake((path, callback) => {
+			callback();
+		});
+		const requireOnStub = sinon.stub().returns({ remove: removeStub });
+		const define = { amd: {} };
+		const require: any = requireStub;
+		require.on = requireOnStub;
+
+		if (typeof window !== 'undefined') {
+			(window as any).define = define;
+			(window as any).require = require;
+		} else {
+			(global as any).define = define;
+			(global as any).require = require;
+		}
+
+		const load = await callback();
+		const path = 'relative_path';
+
+		await load([path]);
+
+		assert.isTrue(requireStub.calledOnce);
+		assert.deepEqual(requireStub.lastCall.args[0], [`${intern.config.basePath}${path}`]);
+
+		assert.isTrue(requireOnStub.calledOnce);
+		assert.strictEqual(requireOnStub.lastCall.args[0], 'error');
+		assert.isFunction(requireOnStub.lastCall.args[1]);
+
+		assert.isTrue(removeStub.calledOnce);
+	});
+
+	it('should throw an error encountered while requiring a module', async () => {
+		let errorCallback: Function;
+		const callback = assertRegisterLoader();
+		const errorMessage = 'Error Message';
+		const removeStub = sinon.stub();
+		const requireOnStub = sinon.stub().callsFake((message, onError) => {
+			errorCallback = onError;
+			return { remove: removeStub };
+		});
+		const requireStub = sinon.stub().callsFake(() => {
+			if (errorCallback) {
+				const emitStub = sinon.stub(intern, 'emit');
+				errorCallback({ message: errorMessage });
+				emitStub.restore();
+				assert.isTrue(emitStub.calledOnce);
+			}
+		});
+		const define = { amd: {} };
+		const require: any = requireStub;
+		require.on = requireOnStub;
+
+		// Make sure it will use define and require from global as well
+		let globalWindow: any;
+		if (typeof window !== 'undefined') {
+			globalWindow = window;
+			delete (global as any).window;
+		}
+		(global as any).define = define;
+		(global as any).require = require;
+
+		const load = await callback();
+		const path = '/absolute_path';
+
+		await load([path]).then(
+			() => {
+				(global as any).window = globalWindow;
+				throw 'Should have been rejected';
+			},
+			(error: Error) => {
+				(global as any).window = globalWindow;
+				assert.deepEqual(error.message, `AMD loader error: ${errorMessage}`);
+			}
+		);
+
+		assert.isTrue(requireStub.calledOnce);
+		assert.deepEqual(requireStub.lastCall.args[0], [path]);
+
+		assert.isTrue(requireOnStub.calledOnce);
+		assert.strictEqual(requireOnStub.lastCall.args[0], 'error');
+
+		assert.isTrue(removeStub.calledOnce);
+	});
+});

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -218,5 +218,30 @@ describe('runTests', () => {
 				"Didn't add default config config"
 			);
 		});
+
+		it('Should pass externals to a loader if provided', () => {
+			const externals = {
+				dependencies: ['foo'],
+				outputPath: 'bar'
+			};
+			assert.include(
+				runTests.parseArguments({
+					childConfig: 'config',
+					externals
+				}),
+				`loader=${JSON.stringify({
+					script: 'node_modules/@dojo/cli-test-intern/loaders/externals.js',
+					options: externals
+				})}`
+			);
+		});
+
+		it('Should throw an error if externals are passed with no config specified', () => {
+			assert.throws(
+				() => runTests.parseArguments({ externals: {} }),
+				'Dojo JIT does not currently support externals, ' +
+					'please specify a config option to run tests against the built code'
+			);
+		});
 	});
 });


### PR DESCRIPTION
**Type:** feature

Provides support for testing against the built unit test bundle when using externals. Injects the specified scripts into the page using intern's load script and delegates to an AMD require for loading the test bundle if one exists.
