### PR TITLE
Down emit to es5

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "./node_modules/@dojo/scripts/tsconfig/commonjs.json",
 	"compilerOptions": {
 		"declaration": false,
+		"downlevelIteration": true,
 		"lib": [
 			"dom",
 			"es5",
@@ -12,9 +13,9 @@
 			"es2015.promise",
 			"es2015.symbol",
 			"es2015.symbol.wellknown",
-      "es2015.proxy"
+			"es2015.proxy"
 		],
-		"target": "es2015",
+		"target": "es5",
 		"types": [ "intern" ]
 	},
 	"include": [


### PR DESCRIPTION
**Type:** bug

When using the externals config, tests fail in some browsers because the externals loader was being compiled to  ES2015. This updates the build to down emit to ES5.