### PR TITLE
Do not use OS specific path separators for intern config

### DIFF
--- a/src/runTests.ts
+++ b/src/runTests.ts
@@ -9,27 +9,27 @@ const packagePath = pkgDir.sync(dirname);
 
 let logger = console.log;
 
-const reporterDir = path.join('output', 'coverage');
+const reporterDir = 'output/coverage';
 const reporterConfigurations: { [index: string]: any } = {
 	benchmark: {
-		directory: path.join(reporterDir, 'benchmark'),
+		directory: `${reporterDir}/benchmark`,
 		filename: 'coverage.xml'
 	},
 	cobertura: {
-		directory: path.join(reporterDir, 'cobertura'),
+		directory: `${reporterDir}/cobertura`,
 		filename: 'coverage.xml'
 	},
 	htmlcoverage: {
-		directory: path.join(reporterDir, 'html')
+		directory: `${reporterDir}/html`
 	},
 	jsoncoverage: {
-		directory: path.join(reporterDir, 'json')
+		directory: `${reporterDir}/json`
 	},
 	junit: {
-		filename: path.join(reporterDir, 'junit', 'coverage.xml')
+		filename: `${reporterDir}/junit/coverage.xml`
 	},
 	lcov: {
-		directory: path.join(reporterDir, 'lcov'),
+		directory: `${reporterDir}/lcov`,
 		filename: 'coverage.lcov'
 	},
 	pretty: 'pretty',

--- a/tests/unit/runTests.ts
+++ b/tests/unit/runTests.ts
@@ -170,12 +170,7 @@ describe('runTests', () => {
 			assert.include(args, 'reporters=runner');
 			assert.include(
 				args,
-				`reporters={ "name": "junit", "options": { "filename": "${path.join(
-					'output',
-					'coverage',
-					'junit',
-					'coverage.xml'
-				)}" } }`
+				`reporters={ "name": "junit", "options": { "filename": "output/coverage/junit/coverage.xml" } }`
 			);
 		});
 
@@ -188,19 +183,11 @@ describe('runTests', () => {
 			assert.include(args, 'reporters=pretty');
 			assert.include(
 				args,
-				`reporters={ "name": "htmlcoverage", "options": { "directory": "${path.join(
-					'output',
-					'coverage',
-					'html'
-				)}" } }`
+				`reporters={ "name": "htmlcoverage", "options": { "directory": "output/coverage/html" } }`
 			);
 			assert.include(
 				args,
-				`reporters={ "name": "lcov", "options": { "directory": "${path.join(
-					'output',
-					'coverage',
-					'lcov'
-				)}", "filename": "coverage.lcov" } }`
+				`reporters={ "name": "lcov", "options": { "directory": "output/coverage/lcov", "filename": "coverage.lcov" } }`
 			);
 		});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

**Description:**

Intern reporters do not require OS specific separators for file paths. Tested on MacOs and Windows VM (win10).

Related to #123 
