### PR TITLE
Specify chrome driver version

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -77,6 +77,11 @@
     },
     "local": {
       "extends": "built",
+      "tunnelOptions": {
+        "drivers": [
+          { "name": "chrome", "version": "76.0.3809.68" }
+        ]
+      },
       "environments": [
         { "browserName": "node" },
         { "browserName": "chrome" }

--- a/src/intern/legacy.json
+++ b/src/intern/legacy.json
@@ -77,6 +77,11 @@
     },
     "local": {
       "extends": "built",
+      "tunnelOptions": {
+        "drivers": [
+          { "name": "chrome", "version": "76.0.3809.68" }
+        ]
+      },
       "environments": [
         { "browserName": "node" },
         { "browserName": "chrome" }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Intern uses a hardcoded configuration for the chrome driver version, currently at 74. The latest version of chrome, 76, is not supported. This manually bumps the driver version to 76.

Resolves #131 131
