### PR TITLE
added configuration for headless chrome browser

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -135,6 +135,22 @@
           "platform": "WIN10"
         }
       ]
+    },
+    "headless": {
+      "extends": "built",
+      "tunnelOptions": {
+        "drivers": [
+          { "name": "chrome", "version": "76.0.3809.68" }
+        ]
+      },
+      "environments": [
+        { 
+          "browserName": "chrome",
+          "goog:chromeOptions": {
+            "args": ["headless", "disable-gpu", "window-size=1920,1080"]
+          } 
+        }
+      ]
     }
   }
 }

--- a/src/intern/legacy.json
+++ b/src/intern/legacy.json
@@ -152,6 +152,22 @@
           "platform": "WIN10"
         }
       ]
+    },
+    "headless": {
+      "extends": "built",
+      "tunnelOptions": {
+        "drivers": [
+          { "name": "chrome", "version": "76.0.3809.68" }
+        ]
+      },
+      "environments": [
+        { 
+          "browserName": "chrome",
+          "goog:chromeOptions": {
+            "args": ["headless", "disable-gpu", "window-size=1920,1080"]
+          } 
+        }
+      ]
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -154,7 +154,7 @@ const command: Command<TestArgs> = {
 
 		options('c', {
 			alias: 'config',
-			describe: `Specifies what configuration to test with: 'local'(default), 'browserstack', 'testingbot', or 'saucelabs'.`,
+			describe: `Specifies what configuration to test with: 'local'(default), 'browserstack', 'testingbot', 'headless' or 'saucelabs'.`,
 			type: 'string'
 		});
 


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Configuration to run tests in a hedless chrome browser
