### PR TITLE
Generating CSS keys

### DIFF
--- a/src/plugins/postcssRequire.ts
+++ b/src/plugins/postcssRequire.ts
@@ -1,8 +1,15 @@
 import Node from 'intern/lib/executors/Node';
+import { join, basename } from 'path';
+import { existsSync } from 'fs';
 
 declare const intern: Node;
 
 const PLUGIN_NAME = 'postcss-node';
+
+const basePath = process.cwd();
+const packageJsonPath = join(basePath, 'package.json');
+const packageJson = existsSync(packageJsonPath) ? require(packageJsonPath) : {};
+const packageName = packageJson.name || '';
 
 /**
  * PostCSS Intern plugin for Node.js
@@ -16,4 +23,21 @@ intern.registerPlugin(PLUGIN_NAME, (options: any = {}) => {
 
 	const hook = require('css-modules-require-hook');
 	hook(options);
+
+	/**
+	 * Dojo themes require a ` _key` property, but css-modules-require-hook doesn't have a way to process the result
+	 * after a module has been generated (only to process CSS).  So instead, we need to wrap the css hook and manually
+	 * create the ` _key` required by theming.
+	 */
+	const postCssExtension = require.extensions['.css'];
+	require.extensions['.css'] = (m, filename) => {
+		postCssExtension(m, filename);
+
+		m.exports = {
+			' _key': `${packageName}/${basename(filename, '.m.css')}`,
+			...m.exports
+		};
+
+		return m;
+	};
 });

--- a/tests/unit/plugins/postcssRequire.ts
+++ b/tests/unit/plugins/postcssRequire.ts
@@ -37,6 +37,8 @@ describe('plugins/postcssRequire', () => {
 	afterEach(() => {
 		sinon.restore();
 		mockModule.destroy();
+
+		delete require.extensions['.css'];
 	});
 
 	it('plugin loads without options', () => {
@@ -58,5 +60,17 @@ describe('plugins/postcssRequire', () => {
 
 	it('not a node environment; warns', () => {
 		assertNotNodeEnvironment(registerPluginStub);
+	});
+
+	it('wraps the postcss extension to add a key', () => {
+		const callback = assertRegisterPlugin();
+
+		require.extensions['.css'] = () => {};
+
+		callback({});
+
+		assert.isFunction(require.extensions['.css']);
+		const result = require.extensions['.css']({ exports: {} } as any, 'test.m.css');
+		assert.deepEqual(result, { exports: { ' _key': '@dojo/cli-test-intern/test' } });
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Generating ` _key` properties for CSS files. There doesn't seem to be a way to modify the output from the `css-modules-require-hook` package, so after calling it, I wrap it in another method that will inject the key value.

Resolves #144 
