### PR TITLE
Fixing has('test') for node tests

### DIFF
--- a/src/intern/intern.json
+++ b/src/intern/intern.json
@@ -34,13 +34,13 @@
       }
     ],
     "plugins": [
-      "@dojo/cli-test-intern/plugins/hasTest",
       {
         "script": "@dojo/cli-test-intern/plugins/jsdom",
         "options": {
           "global": true
         }
       },
+      "@dojo/cli-test-intern/plugins/hasTest",
       "@dojo/cli-test-intern/plugins/postcssRequire",
       "@dojo/cli-test-intern/plugins/tsnode",
       {

--- a/src/intern/legacy.json
+++ b/src/intern/legacy.json
@@ -34,13 +34,13 @@
       }
     ],
     "plugins": [
-      "@dojo/cli-test-intern/plugins/hasTest",
       {
         "script": "@dojo/cli-test-intern/plugins/jsdom",
         "options": {
           "global": true
         }
       },
+      "@dojo/cli-test-intern/plugins/hasTest",
       "@dojo/cli-test-intern/plugins/postcssRequire",
       "@dojo/cli-test-intern/plugins/tsnode",
       {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This is related to https://github.com/dojo/widgets/issues/1250 . The `hasTest` plugin is listed first, so it loads and adds `DojoHasEnvironment` to the global node scope. The `jsdom` plugin then runs which creates a "window" global. During a `has` check, `has` uses the `window` object and therefore does not find the settings in the global node scope.
